### PR TITLE
fix(rust): LAST_MODIFIED_DATE should not be updated when persisting book analysis

### DIFF
--- a/komga-rust/crates/infrastructure/src/task_queue/index_tasks/book_analysis_persistence.rs
+++ b/komga-rust/crates/infrastructure/src/task_queue/index_tasks/book_analysis_persistence.rs
@@ -211,16 +211,6 @@ pub(super) async fn persist_book_analysis(
         })?;
     }
 
-    sqlx::query("UPDATE BOOK SET LAST_MODIFIED_DATE = CURRENT_TIMESTAMP WHERE ID = ?")
-        .bind(book_id)
-        .execute(&mut *tx)
-        .await
-        .map_err(|error| {
-            anyhow::anyhow!(error).context(format!(
-                "failed to refresh BOOK last-modified during analyze for '{book_id}': "
-            ))
-        })?;
-
     tx.commit().await.map_err(|error| {
         anyhow::anyhow!(error).context(format!(
             "failed to commit analyze-book transaction for '{book_id}': "


### PR DESCRIPTION
Remain consistent with the original Komga implementation

dec6208b08adc4f44b66c0978cfbd787a88d26a5 miss it