### PR TITLE
refactor(rust): use the ICU library to unify book and series sorting logic

### DIFF
--- a/komga-rust/Cargo.lock
+++ b/komga-rust/Cargo.lock
@@ -2776,6 +2776,7 @@ dependencies = [
 name = "komga-domain"
 version = "0.1.0"
 dependencies = [
+ "icu",
  "unicode-normalization",
 ]
 
@@ -2786,6 +2787,7 @@ dependencies = [
  "flate2",
  "iepub",
  "image",
+ "indexmap 2.14.2",
  "quick-xml 0.42.0",
  "serde_json",
  "zip 9.0.0-pre3",
@@ -2888,6 +2890,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "image",
+ "indexmap 2.14.2",
  "komga-application",
  "komga-domain",
  "komga-epub",
@@ -2914,6 +2917,7 @@ dependencies = [
  "async-trait",
  "flate2",
  "image",
+ "indexmap 2.14.2",
  "komga-application",
  "komga-build-support",
  "komga-domain",

--- a/komga-rust/Cargo.toml
+++ b/komga-rust/Cargo.toml
@@ -78,6 +78,7 @@ pdfium-render = { version = "0.9.4", git = "https://github.com/ajrcarey/pdfium-r
 unrar = "0.5.8"
 unicode-normalization = "0.1.25"
 icu = "2.3.0"
+indexmap = "2.9.0"
 libc = "0.2.189"
 mimalloc = "0.1.52"
 windows-sys = "0.61.2"

--- a/komga-rust/crates/application/src/discovery/browse_engine/book_sort.rs
+++ b/komga-rust/crates/application/src/discovery/browse_engine/book_sort.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use komga_domain::discovery::compare_book_names;
+
 use super::models::{BookRow, BookSortMode};
 
 pub(super) fn sort_books(
@@ -12,33 +14,20 @@ pub(super) fn sort_books(
         return;
     }
 
+    let fallback_number_sort_desc = sort_modes
+        .last()
+        .map(|m| m.is_descending())
+        .unwrap_or(false);
+
     books.sort_by(|left, right| {
         for sort_mode in sort_modes {
             let ordering = match sort_mode {
-                BookSortMode::TitleAsc => left
-                    .title
-                    .to_ascii_lowercase()
-                    .cmp(&right.title.to_ascii_lowercase()),
-                BookSortMode::TitleDesc => right
-                    .title
-                    .to_ascii_lowercase()
-                    .cmp(&left.title.to_ascii_lowercase()),
-                BookSortMode::NameAsc => left
-                    .name
-                    .to_ascii_lowercase()
-                    .cmp(&right.name.to_ascii_lowercase()),
-                BookSortMode::NameDesc => right
-                    .name
-                    .to_ascii_lowercase()
-                    .cmp(&left.name.to_ascii_lowercase()),
-                BookSortMode::SeriesTitleAsc => left
-                    .series_title_sort
-                    .to_ascii_lowercase()
-                    .cmp(&right.series_title_sort.to_ascii_lowercase()),
-                BookSortMode::SeriesTitleDesc => right
-                    .series_title_sort
-                    .to_ascii_lowercase()
-                    .cmp(&left.series_title_sort.to_ascii_lowercase()),
+                BookSortMode::TitleAsc => compare_book_names(&left.title, &right.title),
+                BookSortMode::TitleDesc => compare_book_names(&right.title, &left.title),
+                BookSortMode::NameAsc => compare_book_names(&left.name, &right.name),
+                BookSortMode::NameDesc => compare_book_names(&right.name, &left.name),
+                BookSortMode::SeriesTitleAsc => compare_book_names(&left.series_title_sort, &right.series_title_sort),
+                BookSortMode::SeriesTitleDesc => compare_book_names(&right.series_title_sort, &left.series_title_sort),
                 BookSortMode::CreatedDateAsc => left.created.cmp(&right.created),
                 BookSortMode::CreatedDateDesc => right.created.cmp(&left.created),
                 BookSortMode::LastModifiedDateAsc => left.last_modified.cmp(&right.last_modified),
@@ -131,7 +120,23 @@ pub(super) fn sort_books(
                 return ordering;
             }
         }
-        left.id.cmp(&right.id)
+        left
+            .series_id
+            .cmp(&right.series_id)
+            .then({
+                if fallback_number_sort_desc {
+                    right
+                        .metadata_number_sort
+                        .partial_cmp(&left.metadata_number_sort)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                } else {
+                    left
+                        .metadata_number_sort
+                        .partial_cmp(&right.metadata_number_sort)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                }
+            })
+            .then(left.id.cmp(&right.id))
     });
 }
 

--- a/komga-rust/crates/application/src/discovery/browse_engine/models.rs
+++ b/komga-rust/crates/application/src/discovery/browse_engine/models.rs
@@ -188,6 +188,32 @@ pub enum BookSortMode {
     RelevanceDesc,
 }
 
+impl BookSortMode {
+    pub(super) fn is_descending(&self) -> bool {
+        matches!(
+            self,
+            BookSortMode::TitleDesc
+                | BookSortMode::NameDesc
+                | BookSortMode::SeriesTitleDesc
+                | BookSortMode::CreatedDateDesc
+                | BookSortMode::LastModifiedDateDesc
+                | BookSortMode::FileSizeDesc
+                | BookSortMode::FileHashDesc
+                | BookSortMode::UrlDesc
+                | BookSortMode::MediaStatusDesc
+                | BookSortMode::MediaCommentDesc
+                | BookSortMode::MediaTypeDesc
+                | BookSortMode::MediaPagesCountDesc
+                | BookSortMode::ReadProgressLastModifiedDateDesc
+                | BookSortMode::ReadProgressReadDateDesc
+                | BookSortMode::ReleaseDateDesc
+                | BookSortMode::NumberSortDesc
+                | BookSortMode::ReadListNumberDesc
+                | BookSortMode::RelevanceDesc
+        )
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SeriesSortMode {
     TitleAsc,

--- a/komga-rust/crates/application/src/discovery/browse_engine/series_sort.rs
+++ b/komga-rust/crates/application/src/discovery/browse_engine/series_sort.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use komga_domain::discovery::compare_book_names;
+
 use super::models::{SeriesEvaluationContext, SeriesRow, SeriesSortMode};
 
 pub(super) fn sort_series(
@@ -25,22 +27,10 @@ pub(super) fn sort_series(
     series.sort_by(|left, right| {
         for sort_mode in sort_modes {
             let ordering = match sort_mode {
-                SeriesSortMode::TitleAsc => left
-                    .title_sort
-                    .to_ascii_lowercase()
-                    .cmp(&right.title_sort.to_ascii_lowercase()),
-                SeriesSortMode::TitleDesc => right
-                    .title_sort
-                    .to_ascii_lowercase()
-                    .cmp(&left.title_sort.to_ascii_lowercase()),
-                SeriesSortMode::NameAsc => left
-                    .name
-                    .to_ascii_lowercase()
-                    .cmp(&right.name.to_ascii_lowercase()),
-                SeriesSortMode::NameDesc => right
-                    .name
-                    .to_ascii_lowercase()
-                    .cmp(&left.name.to_ascii_lowercase()),
+                SeriesSortMode::TitleAsc => compare_book_names(&left.title_sort, &right.title_sort),
+                SeriesSortMode::TitleDesc => compare_book_names(&right.title_sort, &left.title_sort),
+                SeriesSortMode::NameAsc => compare_book_names(&left.name, &right.name),
+                SeriesSortMode::NameDesc => compare_book_names(&right.name, &left.name),
                 SeriesSortMode::ReadDateAsc => {
                     let left_date = eval_ctx.read_dates.as_ref().and_then(|d| d.get(&left.id));
                     let right_date = eval_ctx.read_dates.as_ref().and_then(|d| d.get(&right.id));

--- a/komga-rust/crates/application/src/discovery/collections.rs
+++ b/komga-rust/crates/application/src/discovery/collections.rs
@@ -2,13 +2,8 @@ use std::collections::HashMap;
 
 use crate::random_tokens::random_hex_token;
 use crate::runtime_sse::{RuntimeSseEvent, RuntimeSseEventSink};
-use icu::collator::{
-    Collator,
-    options::{CollatorOptions, Strength},
-};
-use icu::locale::locale;
 use komga_domain::discovery::{
-    DiscoveryQueryContext, PageEnvelope, content_allowed_by_restrictions,
+    DiscoveryQueryContext, PageEnvelope, compare_book_names, content_allowed_by_restrictions,
 };
 
 use super::{
@@ -22,6 +17,18 @@ pub struct CollectionListQuery {
     pub size: usize,
     pub unpaged: bool,
     pub search: Option<String>,
+    pub sort: CollectionsSort,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CollectionsSort {
+    NameAsc,
+    NameDesc,
+    CreatedDateAsc,
+    CreatedDateDesc,
+    LastModifiedDateAsc,
+    LastModifiedDateDesc,
+    SearchOrName,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -118,10 +125,33 @@ where
         }
         content.retain(|collection| !collection.series_ids.is_empty());
 
-        if let Some(search) = query.search.as_deref() {
+        let search_filtered = if let Some(search) = query.search.as_deref() {
             sort_collections_by_search(self.search, &mut content, search, search_limit).await?;
+            true
         } else {
-            sort_collections_by_name(&mut content);
+            false
+        };
+
+        match query.sort {
+            CollectionsSort::SearchOrName => {
+                if !search_filtered {
+                    sort_collections_by_name(&mut content);
+                }
+            }
+            CollectionsSort::NameAsc => sort_collections_by_name(&mut content),
+            CollectionsSort::NameDesc => sort_collections_by_name_desc(&mut content),
+            CollectionsSort::CreatedDateAsc => {
+                sort_collections_by_created_date(&mut content, false)
+            }
+            CollectionsSort::CreatedDateDesc => {
+                sort_collections_by_created_date(&mut content, true)
+            }
+            CollectionsSort::LastModifiedDateAsc => {
+                sort_collections_by_last_modified_date(&mut content, false)
+            }
+            CollectionsSort::LastModifiedDateDesc => {
+                sort_collections_by_last_modified_date(&mut content, true)
+            }
         }
 
         Ok(paginate_collections(
@@ -507,8 +537,27 @@ async fn sort_collections_by_search(
 }
 
 fn sort_collections_by_name(content: &mut [CollectionReadModel]) {
-    let collator = collections_unicode_collator();
-    content.sort_by(|left, right| collator.compare(left.name.as_str(), right.name.as_str()));
+    content.sort_by(|left, right| compare_book_names(left.name.as_str(), right.name.as_str()));
+}
+
+fn sort_collections_by_name_desc(content: &mut [CollectionReadModel]) {
+    content.sort_by(|left, right| compare_book_names(right.name.as_str(), left.name.as_str()));
+}
+
+fn sort_collections_by_created_date(content: &mut [CollectionReadModel], descending: bool) {
+    if descending {
+        content.sort_by(|left, right| right.created_date.cmp(&left.created_date));
+    } else {
+        content.sort_by(|left, right| left.created_date.cmp(&right.created_date));
+    }
+}
+
+fn sort_collections_by_last_modified_date(content: &mut [CollectionReadModel], descending: bool) {
+    if descending {
+        content.sort_by(|left, right| right.last_modified_date.cmp(&left.last_modified_date));
+    } else {
+        content.sort_by(|left, right| left.last_modified_date.cmp(&right.last_modified_date));
+    }
 }
 
 fn paginate_collections(
@@ -536,13 +585,6 @@ fn paginate_collections(
     PageEnvelope::from_slice(page_content, page, page_size, total_elements)
 }
 
-fn collections_unicode_collator() -> icu::collator::CollatorBorrowed<'static> {
-    let mut options = CollatorOptions::default();
-    options.strength = Some(Strength::Tertiary);
-    Collator::try_new(locale!("und").into(), options)
-        .expect("unicode collator for collections sorting should construct")
-}
-
 fn generated_collection_id() -> String {
     format!("collection-{}", random_hex_token(12))
 }
@@ -562,7 +604,8 @@ mod tests {
 
     use super::{
         CollectionListQuery, CollectionMutationError, CollectionMutationInput,
-        CollectionMutationService, CollectionProjectionService, collection_from_record,
+        CollectionMutationService, CollectionProjectionService, CollectionsSort,
+        collection_from_record,
     };
 
     #[tokio::test]
@@ -579,6 +622,7 @@ mod tests {
                     size: 20,
                     unpaged: false,
                     search: Some("space".to_string()),
+                    sort: CollectionsSort::SearchOrName,
                 },
             )
             .await
@@ -595,6 +639,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn collection_projection_service_filters_by_search_before_explicit_sort() {
+        let ports = TestCollectionPorts::new();
+        let service = CollectionProjectionService::new(&ports, &ports, &ports);
+
+        let page = service
+            .list_collections(
+                &context_with_libraries(["library-a", "library-b", "library-c"]),
+                None,
+                CollectionListQuery {
+                    page: 0,
+                    size: 20,
+                    unpaged: false,
+                    search: Some("space".to_string()),
+                    sort: CollectionsSort::NameAsc,
+                },
+            )
+            .await
+            .expect("collections should resolve");
+
+        assert_eq!(page.total_elements, 2);
+        assert_eq!(
+            page.content
+                .iter()
+                .map(|collection| collection.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["Alpha", "Beta"],
+        );
+    }
+
+    #[tokio::test]
     async fn collection_projection_service_sorts_by_name_before_pagination() {
         let ports = TestCollectionPorts::new();
         let service = CollectionProjectionService::new(&ports, &ports, &ports);
@@ -608,6 +682,7 @@ mod tests {
                     size: 2,
                     unpaged: false,
                     search: None,
+                    sort: CollectionsSort::SearchOrName,
                 },
             )
             .await

--- a/komga-rust/crates/application/src/discovery/mod.rs
+++ b/komga-rust/crates/application/src/discovery/mod.rs
@@ -33,7 +33,7 @@ pub use browse_engine::{
 };
 pub use collections::{
     CollectionCreateResult, CollectionListQuery, CollectionMutationError, CollectionMutationInput,
-    CollectionMutationService, CollectionProjectionService,
+    CollectionMutationService, CollectionProjectionService, CollectionsSort,
 };
 pub use detail_port::{
     BookDetailPort, CollectionMutationPort, CollectionPort, CollectionProjectionPort,

--- a/komga-rust/crates/application/src/discovery/readlists.rs
+++ b/komga-rust/crates/application/src/discovery/readlists.rs
@@ -2,15 +2,10 @@ use std::collections::{BTreeMap, HashMap};
 
 use crate::random_tokens::random_hex_token;
 use crate::runtime_sse::{RuntimeSseEvent, RuntimeSseEventSink};
-use icu::collator::{
-    Collator,
-    options::{CollatorOptions, Strength},
-};
-use icu::locale::locale;
 use komga_domain::common_ids::LibraryId;
 use komga_domain::discovery::{
     DiscoveryError, DiscoveryQueryContext, MediaStatus, PageEnvelope, ReadStatus,
-    content_allowed_by_restrictions,
+    compare_book_names, content_allowed_by_restrictions,
 };
 use quick_xml::Reader as XmlReader;
 use quick_xml::XmlVersion;
@@ -1098,21 +1093,13 @@ fn sort_readlists(
 }
 
 fn sort_readlists_by_name(content: &mut [ReadListReadModel], descending: bool) {
-    let collator = readlists_unicode_collator();
     content.sort_by(|left, right| {
         if descending {
-            collator.compare(right.name.as_str(), left.name.as_str())
+            compare_book_names(right.name.as_str(), left.name.as_str())
         } else {
-            collator.compare(left.name.as_str(), right.name.as_str())
+            compare_book_names(left.name.as_str(), right.name.as_str())
         }
     });
-}
-
-fn readlists_unicode_collator() -> icu::collator::CollatorBorrowed<'static> {
-    let mut options = CollatorOptions::default();
-    options.strength = Some(Strength::Tertiary);
-    Collator::try_new(locale!("und").into(), options)
-        .expect("unicode collator for readlists sorting should construct")
 }
 
 fn paginate_readlists(

--- a/komga-rust/crates/config/src/cli_args.rs
+++ b/komga-rust/crates/config/src/cli_args.rs
@@ -16,6 +16,7 @@ pub(crate) const DATABASE_FILE_ENV: &str = "KOMGA_DATABASE_FILE";
 pub(crate) const TASKS_DB_FILE_ENV: &str = "KOMGA_TASKS_DB_FILE";
 pub(crate) const LUCENE_DATA_DIRECTORY_ENV: &str = "KOMGA_LUCENE_DATA_DIRECTORY";
 pub(crate) const FONTS_DATA_DIRECTORY_ENV: &str = "KOMGA_FONTS_DATA_DIRECTORY";
+pub(crate) const SORT_LOCALE_ENV: &str = "KOMGA_SORT_LOCALE";
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct RuntimeCli {

--- a/komga-rust/crates/config/src/env_config.rs
+++ b/komga-rust/crates/config/src/env_config.rs
@@ -16,6 +16,7 @@ use super::startup_policy::{
 use super::writer_ownership::WriterOwnershipPolicy;
 
 pub const DEFAULT_SESSION_MAX_INACTIVE_SECONDS: u64 = 30 * 24 * 60 * 60;
+pub const DEFAULT_SORT_LOCALE: Option<String> = None;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct OAuth2ClientConfig {
@@ -58,6 +59,7 @@ pub struct RuntimeConfig {
     pub writer_ownership_policy: WriterOwnershipPolicy,
     pub session_max_inactive_seconds: u64,
     pub task_pool_size: usize,
+    pub sort_locale: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -154,6 +156,7 @@ impl RuntimeConfig {
             },
             session_max_inactive_seconds: DEFAULT_SESSION_MAX_INACTIVE_SECONDS,
             task_pool_size: 1,
+            sort_locale: DEFAULT_SORT_LOCALE,
         }
     }
 

--- a/komga-rust/crates/config/src/path_resolution/runtime_resolution.rs
+++ b/komga-rust/crates/config/src/path_resolution/runtime_resolution.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use config::Config as LayeredConfig;
 
 use super::super::cli_args::{
-    CONFIG_DIR_ENV, MODE_ENV, PLATFORM_PROFILE_ENV, RUNTIME_PROFILE_ENV, RuntimeCli,
+    CONFIG_DIR_ENV, MODE_ENV, PLATFORM_PROFILE_ENV, RUNTIME_PROFILE_ENV, RuntimeCli, SORT_LOCALE_ENV,
     SPRING_PROFILES_ACTIVE_ENV,
 };
 use super::super::env_config::{
@@ -139,6 +139,25 @@ fn resolve_session_max_inactive_seconds(
         .unwrap_or(DEFAULT_SESSION_MAX_INACTIVE_SECONDS)
 }
 
+fn resolve_sort_locale(
+    layered: &LayeredConfig,
+    env: &BTreeMap<String, String>,
+) -> Option<String> {
+    env.get(SORT_LOCALE_ENV)
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            read_string(
+                layered,
+                &[
+                    "komga.sortLocale",
+                    "komga.sort-locale",
+                    "komga.sort_locale",
+                ],
+            )
+        })
+}
+
 struct ResolvedConfigInputs {
     layered: LayeredConfig,
     resolved_config_dir: PathBuf,
@@ -252,6 +271,7 @@ pub(crate) fn resolve_with_env(
     let oauth2_account_creation = resolve_oauth2_account_creation(&layered, env)?;
     let oidc_email_verification = resolve_oidc_email_verification(&layered, env)?;
     let session_max_inactive_seconds = resolve_session_max_inactive_seconds(&layered, env);
+    let sort_locale = resolve_sort_locale(&layered, env);
 
     let writer_ownership_policy = resolve_writer_ownership_policy_for_startup_slice(cli, env)?;
     let demo_mode = active_profiles_contain_demo(&layered, env);
@@ -280,6 +300,7 @@ pub(crate) fn resolve_with_env(
         writer_ownership_policy,
         session_max_inactive_seconds,
         task_pool_size: 1,
+        sort_locale,
     };
 
     config.validate_single_writer_storage_ownership(env)?;

--- a/komga-rust/crates/domain/Cargo.toml
+++ b/komga-rust/crates/domain/Cargo.toml
@@ -5,4 +5,5 @@ edition.workspace = true
 publish = false
 
 [dependencies]
+icu.workspace = true
 unicode-normalization.workspace = true

--- a/komga-rust/crates/domain/src/discovery/book_name_sort.rs
+++ b/komga-rust/crates/domain/src/discovery/book_name_sort.rs
@@ -1,89 +1,191 @@
-use unicode_normalization::{UnicodeNormalization, char::is_combining_mark};
+use icu::collator::{
+    Collator,
+    options::{CollatorOptions, Strength},
+};
+use icu::locale::{locale, Locale};
+use std::cmp::Ordering;
+use std::sync::OnceLock;
 
-pub fn compare_book_names(left: &str, right: &str) -> std::cmp::Ordering {
-    let left = normalize_sort_key(left);
-    let right = normalize_sort_key(right);
-    natural_cmp(&left, &right)
+pub fn compare_book_names(left: &str, right: &str) -> Ordering {
+    let left = split_into_segments(left);
+    let right = split_into_segments(right);
+    compare_segments(&left, &right)
 }
 
-fn normalize_sort_key(value: &str) -> String {
-    value
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ")
-        .nfd()
-        .filter(|ch| !is_combining_mark(*ch))
-        .flat_map(|ch| ch.to_lowercase())
-        .collect()
+pub fn system_locale_collator() -> &'static icu::collator::CollatorBorrowed<'static> {
+    static COLLATOR: OnceLock<icu::collator::CollatorBorrowed<'static>> = OnceLock::new();
+    COLLATOR.get_or_init(|| {
+        let locale = SORT_LOCALE_OVERRIDE
+            .get()
+            .cloned()
+            .flatten()
+            .unwrap_or_else(|| locale!("und"));
+        let mut options = CollatorOptions::default();
+        options.strength = Some(Strength::Tertiary);
+        Collator::try_new(locale.into(), options)
+            .expect("unicode collator for book name sorting should construct")
+    })
 }
 
-fn natural_cmp(left: &str, right: &str) -> std::cmp::Ordering {
-    use std::cmp::Ordering;
+static SORT_LOCALE_OVERRIDE: OnceLock<Option<Locale>> = OnceLock::new();
 
-    let left = left.as_bytes();
-    let right = right.as_bytes();
-    let mut left_index = 0usize;
-    let mut right_index = 0usize;
+pub fn set_sort_locale(locale: Option<String>) {
+    SORT_LOCALE_OVERRIDE.get_or_init(|| locale.and_then(|l| parse_locale(&l)));
+}
 
-    while left_index < left.len() && right_index < right.len() {
-        let left_is_digit = left[left_index].is_ascii_digit();
-        let right_is_digit = right[right_index].is_ascii_digit();
+fn parse_locale(value: &str) -> Option<Locale> {
+    let lang = value.split('.').next().unwrap_or(value).replace('_', "-");
+    lang.parse().ok()
+}
 
-        if left_is_digit && right_is_digit {
-            let left_end = digit_run_end(left, left_index);
-            let right_end = digit_run_end(right, right_index);
-            let ordering =
-                compare_digit_runs(&left[left_index..left_end], &right[right_index..right_end]);
-            if ordering != Ordering::Equal {
-                return ordering;
+fn book_names_collator() -> &'static icu::collator::CollatorBorrowed<'static> {
+    system_locale_collator()
+}
+
+enum Segment {
+    Text(String),
+    Number(String),
+}
+
+fn split_into_segments(value: &str) -> Vec<Segment> {
+    let normalized = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    if normalized.is_empty() {
+        return vec![Segment::Text(String::new())];
+    }
+    let mut segments = Vec::new();
+    let mut chars = normalized.chars().peekable();
+    while let Some(&ch) = chars.peek() {
+        if ch.is_ascii_digit() {
+            let mut num_str = String::new();
+            while let Some(&d) = chars.peek() {
+                if d.is_ascii_digit() {
+                    num_str.push(chars.next().unwrap());
+                } else {
+                    break;
+                }
             }
-            left_index = left_end;
-            right_index = right_end;
-            continue;
+            if chars.peek() == Some(&'.') {
+                chars.next();
+                num_str.push('.');
+                while let Some(&d) = chars.peek() {
+                    if d.is_ascii_digit() {
+                        num_str.push(chars.next().unwrap());
+                    } else {
+                        break;
+                    }
+                }
+            }
+            segments.push(Segment::Number(num_str));
+        } else {
+            let mut text = String::new();
+            while let Some(&c) = chars.peek() {
+                if !c.is_ascii_digit() {
+                    text.push(chars.next().unwrap());
+                } else {
+                    break;
+                }
+            }
+            segments.push(Segment::Text(text));
+        }
+    }
+    merge_segments(segments)
+}
+
+fn merge_segments(segments: Vec<Segment>) -> Vec<Segment> {
+    let mut result = Vec::new();
+    for segment in segments {
+        match segment {
+            Segment::Text(text) => {
+                if text.is_empty() {
+                    continue;
+                }
+                if let Some(Segment::Text(prev)) = result.last_mut() {
+                    prev.push_str(&text);
+                } else {
+                    result.push(Segment::Text(text));
+                }
+            }
+            Segment::Number(num) => {
+                result.push(Segment::Number(num));
+            }
+        }
+    }
+    if result.is_empty() {
+        result.push(Segment::Text(String::new()));
+    }
+    result
+}
+
+fn compare_numeric_strings(a: &str, b: &str) -> Ordering {
+    let (a_int, a_frac) = match a.split_once('.') {
+        Some((int, frac)) => (int, Some(frac)),
+        None => (a, None),
+    };
+
+    let (b_int, b_frac) = match b.split_once('.') {
+        Some((int, frac)) => (int, Some(frac)),
+        None => (b, None),
+    };
+
+    let a_int = a_int.trim_start_matches('0');
+    let b_int = b_int.trim_start_matches('0');
+
+    let a_int = if a_int.is_empty() { "0" } else { a_int };
+    let b_int = if b_int.is_empty() { "0" } else { b_int };
+
+    let int_cmp = a_int
+        .len()
+        .cmp(&b_int.len())
+        .then_with(|| a_int.cmp(b_int));
+
+    if int_cmp != Ordering::Equal {
+        return int_cmp;
+    }
+
+    match (a_frac, b_frac) {
+        (Some(a_frac), Some(b_frac)) => {
+            let max_len = a_frac.len().max(b_frac.len());
+
+            let a_frac = format!("{:0<width$}", a_frac, width = max_len);
+            let b_frac = format!("{:0<width$}", b_frac, width = max_len);
+
+            a_frac.cmp(&b_frac)
         }
 
-        let ordering = left[left_index].cmp(&right[right_index]);
+        (None, None) => Ordering::Equal,
+
+        (Some(a_frac), None) => {
+            if a_frac.chars().all(|c| c == '0') {
+                Ordering::Equal
+            } else {
+                Ordering::Greater
+            }
+        }
+
+        (None, Some(b_frac)) => {
+            if b_frac.chars().all(|c| c == '0') {
+                Ordering::Equal
+            } else {
+                Ordering::Less
+            }
+        }
+    }
+}
+
+fn compare_segments(left: &[Segment], right: &[Segment]) -> Ordering {
+    use std::cmp::Ordering;
+    let mut left_iter = left.iter();
+    let mut right_iter = right.iter();
+    while let (Some(l), Some(r)) = (left_iter.next(), right_iter.next()) {
+        let ordering = match (l, r) {
+            (Segment::Number(nl), Segment::Number(nr)) => compare_numeric_strings(nl, nr),
+            (Segment::Text(tl), Segment::Text(tr)) => book_names_collator().compare(tl, tr),
+            (Segment::Number(_), Segment::Text(_)) => Ordering::Less,
+            (Segment::Text(_), Segment::Number(_)) => Ordering::Greater,
+        };
         if ordering != Ordering::Equal {
             return ordering;
         }
-        left_index += 1;
-        right_index += 1;
     }
-
     left.len().cmp(&right.len())
-}
-
-fn digit_run_end(bytes: &[u8], start: usize) -> usize {
-    let mut index = start;
-    while index < bytes.len() && bytes[index].is_ascii_digit() {
-        index += 1;
-    }
-    index
-}
-
-fn compare_digit_runs(left: &[u8], right: &[u8]) -> std::cmp::Ordering {
-    use std::cmp::Ordering;
-
-    let left_trimmed = trim_leading_zeroes(left);
-    let right_trimmed = trim_leading_zeroes(right);
-    let significant = left_trimmed.len().cmp(&right_trimmed.len());
-    if significant != Ordering::Equal {
-        return significant;
-    }
-
-    let lexical = left_trimmed.cmp(right_trimmed);
-    if lexical != Ordering::Equal {
-        return lexical;
-    }
-
-    left.len().cmp(&right.len())
-}
-
-fn trim_leading_zeroes(bytes: &[u8]) -> &[u8] {
-    let first_non_zero = bytes.iter().position(|byte| *byte != b'0');
-    match first_non_zero {
-        Some(index) => &bytes[index..],
-        None if bytes.is_empty() => bytes,
-        None => &bytes[bytes.len() - 1..],
-    }
 }

--- a/komga-rust/crates/domain/src/discovery/mod.rs
+++ b/komga-rust/crates/domain/src/discovery/mod.rs
@@ -6,7 +6,7 @@ mod models;
 mod sorts;
 mod write_ports;
 
-pub use book_name_sort::compare_book_names;
+pub use book_name_sort::{compare_book_names, set_sort_locale, system_locale_collator};
 pub use envelopes::PageEnvelope;
 pub use errors::{DiscoveryError, UnsupportedDiscoverySemantics};
 pub use filter::{

--- a/komga-rust/crates/epub/Cargo.toml
+++ b/komga-rust/crates/epub/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 flate2.workspace = true
 iepub.workspace = true
+indexmap.workspace = true
 quick-xml.workspace = true
 serde_json.workspace = true
 zip.workspace = true

--- a/komga-rust/crates/epub/src/analysis.rs
+++ b/komga-rust/crates/epub/src/analysis.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 
 use flate2::Compression;
 use flate2::write::GzEncoder;
+use indexmap::IndexMap;
 use quick_xml::Reader as XmlReader;
 use quick_xml::XmlVersion;
 use quick_xml::events::{BytesStart, Event};
@@ -99,12 +100,11 @@ pub fn analyze_epub_file(path: &Path) -> Result<EpubAnalysis, EpubAnalysisError>
     for item in &spine {
         add_media_file(&mut media_files, item, "EPUB_PAGE", &entries);
     }
-    let mut assets = manifest
+    let assets = manifest
         .values()
         .filter(|item| !spine_id_set.contains(&item.id))
         .cloned()
         .collect::<Vec<_>>();
-    assets.sort_by_key(|item| resource_name(&item.href));
     for item in &assets {
         add_media_file(&mut media_files, item, "EPUB_ASSET", &entries);
     }
@@ -182,11 +182,10 @@ pub fn analyze_epub_file(path: &Path) -> Result<EpubAnalysis, EpubAnalysisError>
     let comment = (!comment_parts.is_empty()).then(|| comment_parts.join(" "));
     let extension_blob =
         encode_extension(positions, is_fixed_layout, &toc, &landmarks, &page_list)?;
-    let mut files = media_files
+    let files = media_files
         .iter()
         .map(|file| file.file_name.clone())
         .collect::<Vec<_>>();
-    files.sort();
 
     Ok(EpubAnalysis {
         page_count,
@@ -207,7 +206,7 @@ fn parse_rootfile(bytes: &[u8]) -> Result<Option<String>, EpubAnalysisError> {
 fn parse_manifest(
     bytes: &[u8],
     rootfile_path: &str,
-) -> Result<HashMap<String, EpubManifestItem>, EpubAnalysisError> {
+) -> Result<IndexMap<String, EpubManifestItem>, EpubAnalysisError> {
     parse_epub_manifest_items(bytes, rootfile_path).map_err(parse_error("parse EPUB manifest"))
 }
 
@@ -295,7 +294,7 @@ fn resource_name(href: &str) -> String {
 
 fn divina_pages<R: Read + Seek>(
     archive: &mut ZipArchive<R>,
-    manifest: &HashMap<String, EpubManifestItem>,
+    manifest: &IndexMap<String, EpubManifestItem>,
     spine: &[EpubManifestItem],
     entries: &HashMap<String, ZipEntryMetadata>,
 ) -> Result<Vec<EpubAnalysisPage>, EpubAnalysisError> {
@@ -625,7 +624,7 @@ fn navigation<R: Read + Seek>(
     archive: &mut ZipArchive<R>,
     package: &[u8],
     rootfile_path: &str,
-    manifest: &HashMap<String, EpubManifestItem>,
+    manifest: &IndexMap<String, EpubManifestItem>,
 ) -> NavigationParts {
     let nav_path = manifest
         .values()

--- a/komga-rust/crates/epub/src/parse.rs
+++ b/komga-rust/crates/epub/src/parse.rs
@@ -1,5 +1,5 @@
-use std::collections::HashMap;
 use std::fmt;
+use indexmap::IndexMap;
 
 use quick_xml::Reader;
 use quick_xml::XmlVersion;
@@ -48,7 +48,7 @@ impl std::error::Error for EpubParseError {}
 pub fn parse_epub_manifest_items(
     package_document: &[u8],
     rootfile_path: &str,
-) -> Result<HashMap<String, EpubManifestItem>, EpubParseError> {
+) -> Result<IndexMap<String, EpubManifestItem>, EpubParseError> {
     parse_manifest_items(package_document, rootfile_path, DEFAULT_MANIFEST_MEDIA_TYPE)
 }
 
@@ -95,10 +95,10 @@ fn parse_manifest_items(
     package_document: &[u8],
     rootfile_path: &str,
     default_media_type: &str,
-) -> Result<HashMap<String, EpubManifestItem>, EpubParseError> {
+) -> Result<IndexMap<String, EpubManifestItem>, EpubParseError> {
     let mut reader = reader_for(package_document);
     let mut buffer = Vec::new();
-    let mut manifest = HashMap::new();
+    let mut manifest = IndexMap::new();
 
     loop {
         match reader.read_event_into(&mut buffer) {

--- a/komga-rust/crates/infrastructure/discovery/src/books/detail.rs
+++ b/komga-rust/crates/infrastructure/discovery/src/books/detail.rs
@@ -40,9 +40,10 @@ pub(crate) async fn load_persisted_book_resource(
     let row = sqlx::query(
         r#"SELECT b.LIBRARY_ID, sm.AGE_RATING,
                 COALESCE((SELECT GROUP_CONCAT(LABEL, char(30))
-                          FROM (SELECT DISTINCT sms.LABEL AS LABEL
+                          FROM (SELECT sms.LABEL AS LABEL
                                 FROM SERIES_METADATA_SHARING sms
-                                WHERE sms.SERIES_ID = s.ID)), '') AS SHARING_LABELS
+                                WHERE sms.SERIES_ID = s.ID
+                                ORDER BY sms.rowid)), '') AS SHARING_LABELS
          FROM BOOK b
          JOIN SERIES s ON s.ID = b.SERIES_ID
          LEFT JOIN SERIES_METADATA sm ON sm.SERIES_ID = s.ID

--- a/komga-rust/crates/infrastructure/discovery/src/books/persistence.rs
+++ b/komga-rust/crates/infrastructure/discovery/src/books/persistence.rs
@@ -113,9 +113,10 @@ fn book_summary_select_sql(include_read_progress: bool) -> &'static str {
                   sm.PUBLISHER AS PUBLISHER,
                   sm.AGE_RATING AS AGE_RATING,
                   COALESCE((SELECT GROUP_CONCAT(GENRE, char(30))
-                            FROM (SELECT DISTINCT smg.GENRE AS GENRE
+                            FROM (SELECT smg.GENRE AS GENRE
                                   FROM SERIES_METADATA_GENRE smg
-                                  WHERE smg.SERIES_ID = s.ID)), '') AS GENRES,
+                                  WHERE smg.SERIES_ID = s.ID
+                                  ORDER BY smg.rowid)), '') AS GENRES,
                   COALESCE(m.STATUS, 'UNKNOWN') AS MEDIA_STATUS,
                   COALESCE(m.MEDIA_TYPE, '') AS MEDIA_TYPE,
                   COALESCE(m.PAGE_COUNT, 0) AS PAGE_COUNT,
@@ -187,9 +188,10 @@ fn book_summary_select_sql(include_read_progress: bool) -> &'static str {
                   sm.PUBLISHER AS PUBLISHER,
                   sm.AGE_RATING AS AGE_RATING,
                   COALESCE((SELECT GROUP_CONCAT(GENRE, char(30))
-                            FROM (SELECT DISTINCT smg.GENRE AS GENRE
+                            FROM (SELECT smg.GENRE AS GENRE
                                   FROM SERIES_METADATA_GENRE smg
-                                  WHERE smg.SERIES_ID = s.ID)), '') AS GENRES,
+                                  WHERE smg.SERIES_ID = s.ID
+                                  ORDER BY smg.rowid)), '') AS GENRES,
                   COALESCE(m.STATUS, 'UNKNOWN') AS MEDIA_STATUS,
                   COALESCE(m.MEDIA_TYPE, '') AS MEDIA_TYPE,
                   COALESCE(m.PAGE_COUNT, 0) AS PAGE_COUNT,
@@ -407,4 +409,33 @@ mod tests {
         assert_eq!(summary.metadata_tags, vec!["Slice, Life"]);
         fixture.close().await;
     }
+
+    #[tokio::test]
+    async fn load_persisted_book_summaries_preserves_series_genre_insertion_order() {
+        let fixture = BootstrappedBookFixture::open("persisted-book-genre-order").await;
+        fixture.insert_library_series().await;
+        fixture.insert_series_metadata().await;
+        fixture.insert_book("book-1").await;
+        fixture.insert_book_metadata("book-1").await;
+
+        for genre in ["Zeta", "Alpha", "Zeta"] {
+            sqlx::query("INSERT INTO SERIES_METADATA_GENRE (SERIES_ID, GENRE) VALUES (?, ?)")
+                .bind("series-1")
+                .bind(genre)
+                .execute(&fixture.pool)
+                .await
+                .expect("genre should be inserted");
+        }
+
+        let summaries = load_persisted_book_summaries(&fixture.pool, None)
+            .await
+            .expect("book summaries should load");
+        let summary = summaries
+            .first()
+            .expect("book summaries should include seeded book");
+
+        assert_eq!(summary.genres, vec!["Zeta", "Alpha", "Zeta"]);
+        fixture.close().await;
+    }
 }
+

--- a/komga-rust/crates/infrastructure/discovery/src/persisted/authors.rs
+++ b/komga-rust/crates/infrastructure/discovery/src/persisted/authors.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeSet;
 use sqlx::{QueryBuilder, Row, Sqlite, SqlitePool};
 use unicode_normalization::{UnicodeNormalization, char::is_combining_mark};
 
+use super::sort_values_icu;
 use crate::records::{AuthorEntry, AuthorsScope};
 
 pub(super) async fn load_persisted_author_names(
@@ -32,7 +33,6 @@ pub(super) async fn load_persisted_author_names(
         separated.push_unseparated(")");
     }
 
-    query.push(r#" ORDER BY lower(a.NAME), a.NAME"#);
 
     let rows = query
         .build()
@@ -41,11 +41,13 @@ pub(super) async fn load_persisted_author_names(
         .context("query persisted author names")?;
 
     let search = author_search_key(search);
-    Ok(rows
+    let mut names: Vec<String> = rows
         .into_iter()
         .map(|row| row.get::<String, _>("NAME"))
         .filter(|name| search.is_empty() || author_search_key(name).contains(&search))
-        .collect())
+        .collect();
+    sort_values_icu(&mut names);
+    Ok(names)
 }
 
 pub(super) async fn load_persisted_author_roles(
@@ -73,7 +75,6 @@ pub(super) async fn load_persisted_author_roles(
         separated.push_unseparated(")");
     }
 
-    query.push(r#" ORDER BY lower(a.ROLE), a.ROLE"#);
 
     let rows = query
         .build()
@@ -81,10 +82,12 @@ pub(super) async fn load_persisted_author_roles(
         .await
         .context("query persisted author roles")?;
 
-    Ok(rows
+    let mut roles: Vec<String> = rows
         .into_iter()
         .map(|row| row.get::<String, _>("ROLE"))
-        .collect())
+        .collect();
+    sort_values_icu(&mut roles);
+    Ok(roles)
 }
 
 fn author_search_key(value: &str) -> String {
@@ -183,7 +186,6 @@ pub(super) async fn load_persisted_authors_by_scope(
         separated.push_unseparated(")");
     }
 
-    query.push(r#" ORDER BY lower(a.NAME), lower(a.ROLE), a.NAME, a.ROLE, b.ID"#);
 
     let rows = query
         .build()
@@ -200,6 +202,13 @@ pub(super) async fn load_persisted_authors_by_scope(
             authors.push(AuthorEntry { name, role });
         }
     }
+
+    let collator = komga_domain::discovery::system_locale_collator();
+    authors.sort_by(|left, right| {
+        collator
+            .compare(&left.name, &right.name)
+            .then_with(|| collator.compare(&left.role, &right.role))
+    });
 
     Ok(authors)
 }

--- a/komga-rust/crates/infrastructure/discovery/src/persisted/facets.rs
+++ b/komga-rust/crates/infrastructure/discovery/src/persisted/facets.rs
@@ -4,6 +4,7 @@ use sqlx::{QueryBuilder, Row, Sqlite, SqlitePool};
 use komga_application::discovery::{ReferentialTagsInclude, ReferentialTagsScope};
 
 use crate::query_values;
+use super::sort_values_icu;
 
 fn push_ids(query: &mut QueryBuilder<Sqlite>, ids: &[String]) {
     let mut separated = query.separated(",");
@@ -119,7 +120,7 @@ pub(super) async fn load_persisted_referential_tags(
     if include != ReferentialTagsInclude::Series {
         push_referential_tag_select(&mut query, scope, authorized_library_ids, false);
     }
-    query.push(") ORDER BY lower(TAG), TAG");
+    query.push(")");
 
     query
         .build()
@@ -127,9 +128,12 @@ pub(super) async fn load_persisted_referential_tags(
         .await
         .context("query persisted referential tags")
         .map(|rows| {
-            rows.into_iter()
+            let mut values: Vec<String> = rows
+                .into_iter()
                 .map(|row| row.get::<String, _>("TAG"))
-                .collect()
+                .collect();
+            sort_values_icu(&mut values);
+            values
         })
 }
 
@@ -138,7 +142,7 @@ pub(super) async fn load_persisted_genres(
     library_ids: Option<&[String]>,
     collection_ids: Option<&[String]>,
 ) -> anyhow::Result<Vec<String>> {
-    query_values::load_persisted_scoped_strings(
+    let mut values = query_values::load_persisted_scoped_strings(
         pool,
         &query_values::ScopedStringQuery {
             library_ids,
@@ -150,10 +154,13 @@ pub(super) async fn load_persisted_genres(
             collection_join: r#" JOIN COLLECTION_SERIES cs ON cs.SERIES_ID = s.ID"#,
             library_column: r#"s.LIBRARY_ID"#,
             extra_condition: None,
-            order_by: "lower(g.GENRE), g.GENRE, s.ID",
+            order_by: None,
         },
     )
-    .await
+    .await?;
+
+    sort_values_icu(&mut values);
+    Ok(values)
 }
 
 pub(super) async fn load_persisted_tags(
@@ -214,7 +221,7 @@ pub(super) async fn load_persisted_tags(
             }
             separated.push_unseparated(")");
         }
-        query.push(r#" ) ORDER BY lower(TAG), TAG"#);
+        query.push(r#" )"#);
         query.build().fetch_all(pool).await
     } else if let Some(library_ids) = library_ids.filter(|ids| !ids.is_empty()) {
         let mut query = QueryBuilder::<Sqlite>::new(
@@ -240,7 +247,7 @@ pub(super) async fn load_persisted_tags(
         for library_id in library_ids {
             separated.push_bind(library_id);
         }
-        separated.push_unseparated(") ) ORDER BY lower(TAG), TAG");
+        separated.push_unseparated(") )");
         query.build().fetch_all(pool).await
     } else {
         sqlx::query(
@@ -252,18 +259,19 @@ pub(super) async fn load_persisted_tags(
                  UNION
                  SELECT bt.TAG AS TAG
                  FROM BOOK_METADATA_TAG bt
-                 JOIN BOOK b ON b.ID = bt.BOOK_ID )
-             ORDER BY lower(TAG), TAG"#,
+                 JOIN BOOK b ON b.ID = bt.BOOK_ID )"#,
         )
         .fetch_all(pool)
         .await
     }
     .context("query persisted tags")?;
 
-    Ok(rows
+    let mut values: Vec<String> = rows
         .into_iter()
         .map(|row| row.get::<String, _>("TAG"))
-        .collect())
+        .collect();
+    sort_values_icu(&mut values);
+    Ok(values)
 }
 
 pub(super) async fn load_persisted_languages(
@@ -271,7 +279,7 @@ pub(super) async fn load_persisted_languages(
     library_ids: Option<&[String]>,
     collection_ids: Option<&[String]>,
 ) -> anyhow::Result<Vec<String>> {
-    query_values::load_persisted_scoped_strings(
+    let mut values = query_values::load_persisted_scoped_strings(
         pool,
         &query_values::ScopedStringQuery {
             library_ids,
@@ -283,10 +291,13 @@ pub(super) async fn load_persisted_languages(
             collection_join: r#" JOIN COLLECTION_SERIES cs ON cs.SERIES_ID = s.ID"#,
             library_column: r#"s.LIBRARY_ID"#,
             extra_condition: Some("sm.LANGUAGE <> ''"),
-            order_by: "lower(sm.LANGUAGE), sm.LANGUAGE",
+            order_by: None,
         },
     )
-    .await
+    .await?;
+
+    sort_values_icu(&mut values);
+    Ok(values)
 }
 
 pub(super) async fn load_persisted_publishers(
@@ -294,7 +305,7 @@ pub(super) async fn load_persisted_publishers(
     library_ids: Option<&[String]>,
     collection_ids: Option<&[String]>,
 ) -> anyhow::Result<Vec<String>> {
-    query_values::load_persisted_scoped_strings(
+    let mut values = query_values::load_persisted_scoped_strings(
         pool,
         &query_values::ScopedStringQuery {
             library_ids,
@@ -306,10 +317,13 @@ pub(super) async fn load_persisted_publishers(
             collection_join: r#" JOIN COLLECTION_SERIES cs ON cs.SERIES_ID = s.ID"#,
             library_column: r#"s.LIBRARY_ID"#,
             extra_condition: Some("sm.PUBLISHER <> ''"),
-            order_by: "lower(sm.PUBLISHER), sm.PUBLISHER",
+            order_by: None,
         },
     )
-    .await
+    .await?;
+
+    sort_values_icu(&mut values);
+    Ok(values)
 }
 
 pub(super) async fn load_persisted_age_ratings(
@@ -374,7 +388,7 @@ pub(super) async fn load_persisted_sharing_labels(
     library_ids: Option<&[String]>,
     collection_ids: Option<&[String]>,
 ) -> anyhow::Result<Vec<String>> {
-    query_values::load_persisted_scoped_strings(
+    let mut values = query_values::load_persisted_scoped_strings(
         pool,
         &query_values::ScopedStringQuery {
             library_ids,
@@ -386,10 +400,13 @@ pub(super) async fn load_persisted_sharing_labels(
             collection_join: r#" JOIN COLLECTION_SERIES cs ON cs.SERIES_ID = s.ID"#,
             library_column: r#"s.LIBRARY_ID"#,
             extra_condition: None,
-            order_by: "lower(sms.LABEL), sms.LABEL",
+            order_by: None,
         },
     )
-    .await
+    .await?;
+
+    sort_values_icu(&mut values);
+    Ok(values)
 }
 
 pub(super) async fn load_persisted_series_release_dates(
@@ -409,7 +426,7 @@ pub(super) async fn load_persisted_series_release_dates(
             collection_join: r#" JOIN COLLECTION_SERIES cs ON cs.SERIES_ID = s.ID"#,
             library_column: r#"s.LIBRARY_ID"#,
             extra_condition: Some("bma.RELEASE_DATE IS NOT NULL AND bma.RELEASE_DATE <> ''"),
-            order_by: "bma.RELEASE_DATE DESC",
+            order_by: Some("bma.RELEASE_DATE DESC"),
         },
     )
     .await?;
@@ -434,7 +451,7 @@ pub(super) async fn load_persisted_series_tags(
     library_ids: Option<&[String]>,
     collection_ids: Option<&[String]>,
 ) -> anyhow::Result<Vec<String>> {
-    query_values::load_persisted_scoped_strings(
+    let mut values = query_values::load_persisted_scoped_strings(
         pool,
         &query_values::ScopedStringQuery {
             library_ids,
@@ -446,8 +463,11 @@ pub(super) async fn load_persisted_series_tags(
             collection_join: r#" JOIN COLLECTION_SERIES cs ON cs.SERIES_ID = st.SERIES_ID"#,
             library_column: r#"s.LIBRARY_ID"#,
             extra_condition: None,
-            order_by: "lower(st.TAG), st.TAG",
+            order_by: None,
         },
     )
-    .await
+    .await?;
+
+    sort_values_icu(&mut values);
+    Ok(values)
 }

--- a/komga-rust/crates/infrastructure/discovery/src/persisted/mod.rs
+++ b/komga-rust/crates/infrastructure/discovery/src/persisted/mod.rs
@@ -7,3 +7,57 @@ pub(crate) mod runtime_queries;
 
 pub use browse::SqliteDiscoveryBrowseService;
 pub use query_support::DiscoveryQuerySupportAccess;
+
+/// Sort string values using the ICU collator (respects the configured sort locale),
+/// matching the Kotlin backend's unicode3 collation semantics.
+pub(super) fn sort_values_icu(values: &mut [String]) {
+    let collator = komga_domain::discovery::system_locale_collator();
+    values.sort_by(|left, right| {
+        // ICU compares canonically equivalent strings (e.g. "é" and "e\u{301}")
+        // as equal; fall back to the raw string ordering so the result is
+        // deterministic regardless of the input row order.
+        collator
+            .compare(left, right)
+            .then_with(|| left.cmp(right))
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sort_values_icu;
+
+    #[test]
+    fn icu_sort_orders_case_and_accents_like_unicode_collation() {
+        let mut values = vec![
+            "b".to_string(),
+            "é".to_string(),
+            "A".to_string(),
+            "a".to_string(),
+            "café".to_string(),
+            "cafe".to_string(),
+        ];
+        sort_values_icu(&mut values);
+        // UCA (und, tertiary): lowercase before uppercase on equal primary,
+        // base letter before accented variant, letter groups ordered by primary,
+        // so: a < A < b < cafe < café < é (é sorts under the e group, after c words)
+        assert_eq!(
+            values,
+            vec!["a", "A", "b", "cafe", "café", "é"]
+        );
+    }
+
+    #[test]
+    fn icu_sort_breaks_canonical_equivalence_ties_by_raw_string() {
+        let mut values = vec![
+            "b".to_string(),
+            "a\u{301}".to_string(),
+            "á".to_string(),
+            "a".to_string(),
+        ];
+        sort_values_icu(&mut values);
+        // "á" (U+00E1) and "a\u{301}" (a + combining acute) are canonically
+        // equivalent and compare equal under ICU; the raw-string fallback
+        // orders them deterministically regardless of the input row order.
+        assert_eq!(values, vec!["a", "a\u{301}", "á", "b"]);
+    }
+}

--- a/komga-rust/crates/infrastructure/discovery/src/persisted/runtime_queries.rs
+++ b/komga-rust/crates/infrastructure/discovery/src/persisted/runtime_queries.rs
@@ -6,6 +6,8 @@ use sqlx::{QueryBuilder, Row, Sqlite, SqlitePool};
 
 use crate::records::{BookBrowseEntry, BookTagsScope};
 
+use super::sort_values_icu;
+
 pub(super) async fn load_persisted_ondeck_books(
     pool: &SqlitePool,
     user_id: &str,
@@ -112,7 +114,6 @@ pub(super) async fn load_persisted_book_tags(
                 }
                 separated.push_unseparated(")");
             }
-            query.push(r#" ORDER BY lower(bt.TAG), bt.TAG, b.ID"#);
             query.build().fetch_all(pool).await
         }
         BookTagsScope::Series(series_id) => {
@@ -133,7 +134,6 @@ pub(super) async fn load_persisted_book_tags(
                 }
                 separated.push_unseparated(")");
             }
-            query.push(r#" ORDER BY lower(bt.TAG), bt.TAG, b.ID"#);
             query.build().fetch_all(pool).await
         }
         BookTagsScope::Libraries(library_ids) => {
@@ -158,7 +158,6 @@ pub(super) async fn load_persisted_book_tags(
                 }
                 separated.push_unseparated(")");
             }
-            query.push(r#" ORDER BY lower(bt.TAG), bt.TAG, b.ID"#);
             query.build().fetch_all(pool).await
         }
         BookTagsScope::ReadList(readlist_id) => {
@@ -180,7 +179,6 @@ pub(super) async fn load_persisted_book_tags(
                 }
                 separated.push_unseparated(")");
             }
-            query.push(r#" ORDER BY lower(bt.TAG), bt.TAG, b.ID"#);
             query.build().fetch_all(pool).await
         }
     }
@@ -194,6 +192,7 @@ pub(super) async fn load_persisted_book_tags(
             tags.push(tag);
         }
     }
+    sort_values_icu(&mut tags);
 
     Ok(tags)
 }

--- a/komga-rust/crates/infrastructure/discovery/src/query_values.rs
+++ b/komga-rust/crates/infrastructure/discovery/src/query_values.rs
@@ -12,7 +12,7 @@ pub(super) struct ScopedStringQuery<'a> {
     pub collection_join: &'a str,
     pub library_column: &'a str,
     pub extra_condition: Option<&'a str>,
-    pub order_by: &'a str,
+    pub order_by: Option<&'a str>,
 }
 
 pub(super) async fn load_persisted_scoped_strings(
@@ -59,8 +59,10 @@ pub(super) async fn load_persisted_scoped_strings(
         builder.push(extra_condition);
     }
 
-    builder.push(" ORDER BY ");
-    builder.push(query.order_by);
+    if let Some(order_by) = query.order_by {
+        builder.push(" ORDER BY ");
+        builder.push(order_by);
+    }
 
     let rows = builder.build().fetch_all(pool).await.map_err(|error| {
         anyhow::anyhow!(error).context(format!("query persisted {}: ", query.label))

--- a/komga-rust/crates/infrastructure/discovery/src/series/detail.rs
+++ b/komga-rust/crates/infrastructure/discovery/src/series/detail.rs
@@ -17,9 +17,10 @@ pub(crate) async fn load_persisted_series_resource(
     let row = sqlx::query(
         r#"SELECT s.LIBRARY_ID, sm.AGE_RATING,
                 COALESCE((SELECT GROUP_CONCAT(LABEL, char(30))
-                          FROM (SELECT DISTINCT sms.LABEL AS LABEL
+                          FROM (SELECT sms.LABEL AS LABEL
                                 FROM SERIES_METADATA_SHARING sms
-                                WHERE sms.SERIES_ID = s.ID)), '') AS SHARING_LABELS
+                                WHERE sms.SERIES_ID = s.ID
+                                ORDER BY sms.rowid)), '') AS SHARING_LABELS
          FROM SERIES s
          LEFT JOIN SERIES_METADATA sm ON sm.SERIES_ID = s.ID
          WHERE s.ID = ?
@@ -78,9 +79,10 @@ pub(crate) async fn load_persisted_series_detail(
                 COALESCE(sm.CREATED_DATE, s.CREATED_DATE) AS METADATA_CREATED,
                 COALESCE(sm.LAST_MODIFIED_DATE, s.LAST_MODIFIED_DATE) AS METADATA_LAST_MODIFIED,
                 COALESCE((SELECT GROUP_CONCAT(LABEL, char(30))
-                          FROM (SELECT DISTINCT sms.LABEL AS LABEL
+                          FROM (SELECT sms.LABEL AS LABEL
                                 FROM SERIES_METADATA_SHARING sms
-                                WHERE sms.SERIES_ID = s.ID)), '') AS SHARING_LABELS
+                                WHERE sms.SERIES_ID = s.ID
+                                ORDER BY sms.rowid)), '') AS SHARING_LABELS
          FROM SERIES s
          LEFT JOIN SERIES_METADATA sm ON sm.SERIES_ID = s.ID
          WHERE s.ID = ?
@@ -207,7 +209,7 @@ pub(crate) async fn load_existing_series_metadata(
     };
 
     let genres = sqlx::query(
-        r#"SELECT GENRE FROM SERIES_METADATA_GENRE WHERE SERIES_ID = ? ORDER BY GENRE COLLATE NOCASE ASC"#,
+        r#"SELECT DISTINCT GENRE FROM SERIES_METADATA_GENRE WHERE SERIES_ID = ? ORDER BY rowid ASC"#,
     )
     .bind(series_id)
     .fetch_all(pool)
@@ -218,7 +220,7 @@ pub(crate) async fn load_existing_series_metadata(
     .collect::<Vec<_>>();
 
     let tags = sqlx::query(
-        r#"SELECT TAG FROM SERIES_METADATA_TAG WHERE SERIES_ID = ? ORDER BY TAG COLLATE NOCASE ASC"#,
+        r#"SELECT DISTINCT TAG FROM SERIES_METADATA_TAG WHERE SERIES_ID = ? ORDER BY rowid ASC"#,
     )
     .bind(series_id)
     .fetch_all(pool)
@@ -229,9 +231,9 @@ pub(crate) async fn load_existing_series_metadata(
     .collect::<Vec<_>>();
 
     let sharing_labels = sqlx::query(
-        r#"SELECT LABEL FROM SERIES_METADATA_SHARING
+        r#"SELECT DISTINCT LABEL FROM SERIES_METADATA_SHARING
              WHERE SERIES_ID = ?
-             ORDER BY LABEL COLLATE NOCASE ASC"#,
+             ORDER BY rowid ASC"#,
     )
     .bind(series_id)
     .fetch_all(pool)
@@ -244,7 +246,7 @@ pub(crate) async fn load_existing_series_metadata(
     let links = sqlx::query(
         r#"SELECT LABEL, URL FROM SERIES_METADATA_LINK
              WHERE SERIES_ID = ?
-             ORDER BY LABEL COLLATE NOCASE ASC, URL ASC"#,
+             ORDER BY rowid ASC"#,
     )
     .bind(series_id)
     .fetch_all(pool)
@@ -260,7 +262,7 @@ pub(crate) async fn load_existing_series_metadata(
     let alternate_titles = sqlx::query(
         r#"SELECT LABEL, TITLE FROM SERIES_METADATA_ALTERNATE_TITLE
              WHERE SERIES_ID = ?
-             ORDER BY LABEL COLLATE NOCASE ASC, TITLE COLLATE NOCASE ASC"#,
+             ORDER BY rowid ASC"#,
     )
     .bind(series_id)
     .fetch_all(pool)
@@ -511,3 +513,99 @@ pub(crate) async fn refresh_series_after_metadata_update(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use komga_infrastructure_test_support::BootstrappedBookFixture;
+
+    #[tokio::test]
+    async fn load_existing_series_metadata_preserves_metadata_insertion_order() {
+        let fixture = BootstrappedBookFixture::open("series-detail-metadata-order").await;
+        fixture.insert_library_series().await;
+        fixture.insert_series_metadata().await;
+
+        for genre in ["Zeta", "Alpha", "Zeta"] {
+            sqlx::query("INSERT INTO SERIES_METADATA_GENRE (SERIES_ID, GENRE) VALUES (?, ?)")
+                .bind("series-1")
+                .bind(genre)
+                .execute(&fixture.pool)
+                .await
+                .expect("genre should be inserted");
+        }
+        for tag in ["Omega", "Beta", "Omega"] {
+            sqlx::query("INSERT INTO SERIES_METADATA_TAG (SERIES_ID, TAG) VALUES (?, ?)")
+                .bind("series-1")
+                .bind(tag)
+                .execute(&fixture.pool)
+                .await
+                .expect("tag should be inserted");
+        }
+        for label in ["Zed", "Alpha", "Zed"] {
+            sqlx::query("INSERT INTO SERIES_METADATA_SHARING (SERIES_ID, LABEL) VALUES (?, ?)")
+                .bind("series-1")
+                .bind(label)
+                .execute(&fixture.pool)
+                .await
+                .expect("sharing label should be inserted");
+        }
+        for (label, url) in [("Zed", "https://z.example"), ("Alpha", "https://a.example")] {
+            sqlx::query("INSERT INTO SERIES_METADATA_LINK (SERIES_ID, LABEL, URL) VALUES (?, ?, ?)")
+                .bind("series-1")
+                .bind(label)
+                .bind(url)
+                .execute(&fixture.pool)
+                .await
+                .expect("series link should be inserted");
+        }
+        for (label, title) in [("en", "Second Title"), ("en", "First Title")] {
+            sqlx::query(
+                "INSERT INTO SERIES_METADATA_ALTERNATE_TITLE (SERIES_ID, LABEL, TITLE) VALUES (?, ?, ?)",
+            )
+            .bind("series-1")
+            .bind(label)
+            .bind(title)
+            .execute(&fixture.pool)
+            .await
+            .expect("alternate title should be inserted");
+        }
+
+        let metadata = load_existing_series_metadata(&fixture.pool, "series-1")
+            .await
+            .expect("series metadata should load")
+            .expect("series metadata should exist");
+
+        assert_eq!(metadata.genres, vec!["Zeta", "Alpha"]);
+        assert_eq!(metadata.tags, vec!["Omega", "Beta"]);
+        assert_eq!(metadata.sharing_labels, vec!["Zed", "Alpha"]);
+        assert_eq!(
+            metadata.links,
+            vec![
+                SeriesMetadataLinkRecord {
+                    label: "Zed".to_string(),
+                    url: "https://z.example".to_string(),
+                },
+                SeriesMetadataLinkRecord {
+                    label: "Alpha".to_string(),
+                    url: "https://a.example".to_string(),
+                },
+            ]
+        );
+        assert_eq!(
+            metadata.alternate_titles,
+            vec![
+                SeriesAlternateTitleRecord {
+                    label: "en".to_string(),
+                    title: "Second Title".to_string(),
+                },
+                SeriesAlternateTitleRecord {
+                    label: "en".to_string(),
+                    title: "First Title".to_string(),
+                },
+            ]
+        );
+        fixture.close().await;
+    }
+}
+
+

--- a/komga-rust/crates/infrastructure/discovery/src/series/persistence.rs
+++ b/komga-rust/crates/infrastructure/discovery/src/series/persistence.rs
@@ -88,48 +88,55 @@ async fn fetch_persisted_series_summary_rows(
                    COALESCE(bma.LAST_MODIFIED_DATE, s.LAST_MODIFIED_DATE) AS BOOKS_METADATA_LAST_MODIFIED,
                    s.NAME AS NAME,
                    COALESCE((SELECT GROUP_CONCAT(LABEL, char(30))
-                             FROM (SELECT DISTINCT sms.LABEL AS LABEL
+                             FROM (SELECT sms.LABEL AS LABEL
                                    FROM SERIES_METADATA_SHARING sms
-                                   WHERE sms.SERIES_ID = s.ID)), '') AS LABELS,
+                                   WHERE sms.SERIES_ID = s.ID
+                                   ORDER BY sms.rowid)), '') AS LABELS,
                   COALESCE((SELECT GROUP_CONCAT(GENRE, char(30))
-                            FROM (SELECT DISTINCT smg.GENRE AS GENRE
+                            FROM (SELECT smg.GENRE AS GENRE
                                   FROM SERIES_METADATA_GENRE smg
-                                  WHERE smg.SERIES_ID = s.ID)), '') AS GENRES,
+                                  WHERE smg.SERIES_ID = s.ID
+                                  ORDER BY smg.rowid)), '') AS GENRES,
                   COALESCE((SELECT GROUP_CONCAT(TAG, char(30))
-                            FROM (SELECT DISTINCT smt.TAG AS TAG
+                            FROM (SELECT smt.TAG AS TAG
                                   FROM SERIES_METADATA_TAG smt
-                                  WHERE smt.SERIES_ID = s.ID)), '') AS TAGS,
+                                  WHERE smt.SERIES_ID = s.ID
+                                  ORDER BY smt.rowid)), '') AS TAGS,
                   COALESCE(
                     (SELECT GROUP_CONCAT(ALTERNATE_TITLE, char(30))
-                     FROM (SELECT DISTINCT CASE
+                     FROM (SELECT CASE
                              WHEN smat.LABEL IS NULL OR smat.LABEL = '' THEN smat.TITLE
                              ELSE smat.LABEL || '::' || smat.TITLE
                            END AS ALTERNATE_TITLE
                            FROM SERIES_METADATA_ALTERNATE_TITLE smat
-                           WHERE smat.SERIES_ID = s.ID)),
+                           WHERE smat.SERIES_ID = s.ID
+                           ORDER BY smat.rowid)),
                     ''
                   ) AS ALTERNATE_TITLES,
                   COALESCE(
                     (SELECT GROUP_CONCAT(LINK, char(30))
-                     FROM (SELECT DISTINCT sml.LABEL || char(31) || sml.URL AS LINK
+                     FROM (SELECT sml.LABEL || char(31) || sml.URL AS LINK
                            FROM SERIES_METADATA_LINK sml
-                           WHERE sml.SERIES_ID = s.ID)),
+                           WHERE sml.SERIES_ID = s.ID
+                           ORDER BY sml.rowid)),
                     ''
                   ) AS LINKS,
                   COALESCE(
                     (SELECT GROUP_CONCAT(AUTHOR, char(30))
-                     FROM (SELECT DISTINCT CASE
+                     FROM (SELECT CASE
                              WHEN bmaa.ROLE IS NULL OR bmaa.ROLE = '' THEN bmaa.NAME
                              ELSE bmaa.NAME || '::' || bmaa.ROLE
                            END AS AUTHOR
                            FROM BOOK_METADATA_AGGREGATION_AUTHOR bmaa
-                           WHERE bmaa.SERIES_ID = s.ID)),
+                           WHERE bmaa.SERIES_ID = s.ID
+                           ORDER BY bmaa.rowid)),
                     ''
                   ) AS BOOKS_METADATA_AUTHORS,
                   COALESCE((SELECT GROUP_CONCAT(TAG, char(30))
-                            FROM (SELECT DISTINCT bmat.TAG AS TAG
+                            FROM (SELECT bmat.TAG AS TAG
                                   FROM BOOK_METADATA_AGGREGATION_TAG bmat
-                                  WHERE bmat.SERIES_ID = s.ID)), '') AS BOOKS_METADATA_TAGS
+                                  WHERE bmat.SERIES_ID = s.ID
+                                  ORDER BY bmat.rowid)), '') AS BOOKS_METADATA_TAGS
            FROM SERIES s
            LEFT JOIN SERIES_METADATA sm ON sm.SERIES_ID = s.ID
            LEFT JOIN BOOK_METADATA_AGGREGATION bma ON bma.SERIES_ID = s.ID"#,
@@ -398,4 +405,95 @@ mod tests {
         assert!(summary.alternate_titles_lock);
         fixture.close().await;
     }
+
+    #[tokio::test]
+    async fn load_persisted_series_summaries_preserves_multi_value_insertion_order() {
+        let fixture = BootstrappedBookFixture::open("series-summary-insertion-order").await;
+        fixture.insert_library_series().await;
+        fixture.insert_series_metadata().await;
+
+        for label in ["Beta", "Alpha", "Beta"] {
+            sqlx::query("INSERT INTO SERIES_METADATA_SHARING (SERIES_ID, LABEL) VALUES (?, ?)")
+                .bind("series-1")
+                .bind(label)
+                .execute(&fixture.pool)
+                .await
+                .expect("sharing label should be inserted");
+        }
+        for genre in ["Zeta", "Alpha", "Zeta"] {
+            sqlx::query("INSERT INTO SERIES_METADATA_GENRE (SERIES_ID, GENRE) VALUES (?, ?)")
+                .bind("series-1")
+                .bind(genre)
+                .execute(&fixture.pool)
+                .await
+                .expect("genre should be inserted");
+        }
+        for tag in ["Omega", "Beta", "Omega"] {
+            sqlx::query("INSERT INTO SERIES_METADATA_TAG (SERIES_ID, TAG) VALUES (?, ?)")
+                .bind("series-1")
+                .bind(tag)
+                .execute(&fixture.pool)
+                .await
+                .expect("tag should be inserted");
+        }
+        for (label, url) in [("Zed", "https://z.example"), ("Alpha", "https://a.example")] {
+            sqlx::query("INSERT INTO SERIES_METADATA_LINK (SERIES_ID, LABEL, URL) VALUES (?, ?, ?)")
+                .bind("series-1")
+                .bind(label)
+                .bind(url)
+                .execute(&fixture.pool)
+                .await
+                .expect("series link should be inserted");
+        }
+        for (label, title) in [("en", "Second Title"), ("en", "First Title")] {
+            sqlx::query(
+                "INSERT INTO SERIES_METADATA_ALTERNATE_TITLE (SERIES_ID, LABEL, TITLE) VALUES (?, ?, ?)",
+            )
+            .bind("series-1")
+            .bind(label)
+            .bind(title)
+            .execute(&fixture.pool)
+            .await
+            .expect("alternate title should be inserted");
+        }
+
+        let summaries = load_persisted_series_summaries(&fixture.pool)
+            .await
+            .expect("series summary should load");
+        let summary = summaries
+            .first()
+            .expect("series summary should include seeded series");
+
+        assert_eq!(summary.labels, vec!["Beta", "Alpha", "Beta"]);
+        assert_eq!(summary.genres, vec!["Zeta", "Alpha", "Zeta"]);
+        assert_eq!(summary.tags, vec!["Omega", "Beta", "Omega"]);
+        assert_eq!(
+            summary.links,
+            vec![
+                SeriesMetadataLinkRecord {
+                    label: "Zed".to_string(),
+                    url: "https://z.example".to_string(),
+                },
+                SeriesMetadataLinkRecord {
+                    label: "Alpha".to_string(),
+                    url: "https://a.example".to_string(),
+                },
+            ]
+        );
+        assert_eq!(
+            summary.alternate_titles,
+            vec![
+                SeriesAlternateTitleRecord {
+                    label: "en".to_string(),
+                    title: "Second Title".to_string(),
+                },
+                SeriesAlternateTitleRecord {
+                    label: "en".to_string(),
+                    title: "First Title".to_string(),
+                },
+            ]
+        );
+        fixture.close().await;
+    }
 }
+

--- a/komga-rust/crates/infrastructure/media-access/Cargo.toml
+++ b/komga-rust/crates/infrastructure/media-access/Cargo.toml
@@ -15,6 +15,7 @@ komga-infrastructure-base = { path = "../base" }
 komga-infrastructure-media-core = { path = "../media-core" }
 komga-infrastructure-media-library = { path = "../media-library" }
 komga-infrastructure-media-metadata = { path = "../media-metadata" }
+indexmap.workspace = true
 pdfium-render.workspace = true
 quick-xml.workspace = true
 serde_json.workspace = true

--- a/komga-rust/crates/infrastructure/media-access/src/transient/epub.rs
+++ b/komga-rust/crates/infrastructure/media-access/src/transient/epub.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
 use std::io::Read;
 
+use indexmap::IndexMap;
 use quick_xml::Reader as XmlReader;
 use quick_xml::XmlVersion;
 use quick_xml::events::Event as XmlEvent;
@@ -86,7 +86,7 @@ fn compute_transient_epub_page_count<R: Read + std::io::Seek>(
 
 fn extract_transient_epub_divina_pages<R: Read + std::io::Seek>(
     archive: &mut ZipArchive<R>,
-    manifest: &HashMap<String, TransientEpubManifestItem>,
+    manifest: &IndexMap<String, TransientEpubManifestItem>,
     spine: &[TransientEpubManifestItem],
 ) -> anyhow::Result<Vec<TransientBookPage>> {
     let mut pages = Vec::new();
@@ -181,7 +181,7 @@ pub(super) fn parse_transient_epub_rootfile_path(container_xml: &[u8]) -> Option
 pub(super) fn parse_transient_epub_manifest_items(
     package_document: &[u8],
     rootfile_path: &str,
-) -> anyhow::Result<HashMap<String, TransientEpubManifestItem>> {
+) -> anyhow::Result<IndexMap<String, TransientEpubManifestItem>> {
     parse_epub_manifest_items(package_document, rootfile_path)
         .map(|manifest| {
             manifest
@@ -202,7 +202,7 @@ pub(super) fn parse_transient_epub_manifest_items(
 
 pub(super) fn parse_transient_epub_spine_items(
     package_document: &[u8],
-    manifest: &HashMap<String, TransientEpubManifestItem>,
+    manifest: &IndexMap<String, TransientEpubManifestItem>,
 ) -> anyhow::Result<Vec<TransientEpubManifestItem>> {
     let spine_ids = parse_epub_spine_itemrefs(package_document)
         .map_err(|error| anyhow::anyhow!(error).context("parse transient EPUB spine"))?;

--- a/komga-rust/crates/infrastructure/media-core/Cargo.toml
+++ b/komga-rust/crates/infrastructure/media-core/Cargo.toml
@@ -12,6 +12,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 flate2.workspace = true
 image.workspace = true
+indexmap.workspace = true
 komga-application = { path = "../../application" }
 komga-domain = { path = "../../domain" }
 komga-epub = { path = "../../epub" }

--- a/komga-rust/crates/infrastructure/media-core/src/content/epub_resources.rs
+++ b/komga-rust/crates/infrastructure/media-core/src/content/epub_resources.rs
@@ -125,7 +125,7 @@ fn extract_image_from_html_page<R: Read + Seek>(
     archive: &mut ZipArchive<R>,
     page_path: &str,
     opf_dir: &str,
-    manifest: &std::collections::HashMap<String, komga_epub::EpubManifestItem>,
+    manifest: &indexmap::IndexMap<String, komga_epub::EpubManifestItem>,
     archive_path: &Path,
 ) -> anyhow::Result<Option<komga_epub::EpubManifestItem>> {
     let html_bytes = read_zip_entry_bytes_normalized_result(archive, page_path, archive_path)?;

--- a/komga-rust/crates/infrastructure/media-core/src/content/page_rendering.rs
+++ b/komga-rust/crates/infrastructure/media-core/src/content/page_rendering.rs
@@ -10,6 +10,7 @@ use komga_application::media_assets::{
     book_media_is_epub, book_media_is_pdf, book_media_is_rar_archive, book_media_is_single_image,
     book_media_is_zip_archive, content_type_from_filename, is_supported_page_image_file_name,
 };
+use komga_domain::discovery::compare_book_names;
 use lopdf::Document as PdfDocument;
 use pdfium_render::prelude::*;
 use zip::ZipArchive;
@@ -44,11 +45,13 @@ pub async fn resolve_book_page_bytes(
             )));
         }
     };
-    if media_path_is_directory {
-        candidates.push(media.file_path.join(&page.file_name));
-    }
-    if let Some(parent) = media.file_path.parent() {
-        candidates.push(parent.join(&page.file_name));
+    if !page.file_name.is_empty() {
+        if media_path_is_directory {
+            candidates.push(media.file_path.join(&page.file_name));
+        }
+        if let Some(parent) = media.file_path.parent() {
+            candidates.push(parent.join(&page.file_name));
+        }
     }
     if book_media_is_single_image(media) && page_number == 1 {
         candidates.push(media.file_path.clone());
@@ -510,9 +513,9 @@ async fn read_zip_archive_page_bytes(
         let target_index = usize::try_from(page_number.saturating_sub(1)).map_err(|error| {
             anyhow::anyhow!(error).context(format!("convert zip page number {page_number}"))
         })?;
-        let mut logical_index = 0usize;
+        let mut supported = Vec::new();
         for index in 0..archive.len() {
-            let mut entry = archive.by_index(index).map_err(|error| {
+            let entry = archive.by_index(index).map_err(|error| {
                 anyhow::anyhow!(error).context(format!(
                     "read zip archive entry #{index} from '{}': ",
                     path.display()
@@ -530,21 +533,26 @@ async fn read_zip_archive_page_bytes(
             if !is_supported_page_image_file_name(&entry_name) {
                 continue;
             }
-            if logical_index != target_index {
-                logical_index += 1;
-                continue;
-            }
-            let mut bytes = Vec::new();
-            entry.read_to_end(&mut bytes).map_err(|error| {
-                anyhow::anyhow!(error).context(format!(
-                    "read zip archive entry '{}' from '{}': ",
-                    entry_name,
-                    path.display()
-                ))
-            })?;
-            return Ok(Some(bytes));
+            supported.push(entry_name);
         }
-        Ok(None)
+        supported.sort_by(|left, right| compare_book_names(left, right));
+        let Some(entry_name) = supported.get(target_index).map(|name| name.as_str()) else {
+            return Ok(None);
+        };
+        let mut entry = archive.by_name(entry_name).map_err(|error| {
+            anyhow::anyhow!(error).context(format!(
+                "read zip archive entry '{entry_name}' from '{}': ",
+                path.display()
+            ))
+        })?;
+        let mut bytes = Vec::new();
+        entry.read_to_end(&mut bytes).map_err(|error| {
+            anyhow::anyhow!(error).context(format!(
+                "read zip archive entry '{entry_name}' from '{}': ",
+                path.display()
+            ))
+        })?;
+        Ok(Some(bytes))
     })
     .await
     .context("join zip archive page read task")?
@@ -597,6 +605,10 @@ async fn load_zip_archive_page_rows(
                 file_size: entry.size().try_into().unwrap_or(i64::MAX),
             });
         }
+        rows.sort_by(|left, right| compare_book_names(&left.file_name, &right.file_name));
+        for (index, row) in rows.iter_mut().enumerate() {
+            row.number = (index as u64) + 1;
+        }
         Ok((!rows.is_empty()).then_some(rows))
     })
     .await
@@ -625,6 +637,11 @@ fn load_rar_archive_page_rows(
             file_size: entry.unpacked_size.try_into().unwrap_or(i64::MAX),
         })
         .collect::<Vec<_>>();
+    let mut rows = rows;
+    rows.sort_by(|left, right| compare_book_names(&left.file_name, &right.file_name));
+    for (index, row) in rows.iter_mut().enumerate() {
+        row.number = (index as u64) + 1;
+    }
     Ok((!rows.is_empty()).then_some(rows))
 }
 
@@ -1034,6 +1051,53 @@ mod tests {
             .await
             .expect("zip page bytes should read");
         assert_eq!(bytes, Some(b"page-2".to_vec()));
+
+        let _ = fs::remove_file(file_path);
+    }
+
+    #[tokio::test]
+    async fn resolve_book_page_bytes_fallback_matches_sorted_rows_for_unsorted_archive() {
+        let file_path = unique_temp_path("komga-media-zip-unsorted");
+        let archive = build_test_zip_archive(vec![
+            ("002.png".to_string(), b"page-2".to_vec()),
+            ("001.jpg".to_string(), b"page-1".to_vec()),
+        ])
+        .expect("zip payload should be created");
+        fs::write(&file_path, archive).expect("zip test file should be written");
+
+        let media = BookMediaRecord {
+            library_id: "lib".to_string(),
+            file_name: "book.cbz".to_string(),
+            file_path: file_path.clone(),
+            media_type: "application/vnd.comicbook+zip".to_string(),
+            page_count: 2,
+        };
+        let page = BookPageRecord {
+            number: 1,
+            file_name: "not-present.jpg".to_string(),
+            media_type: "image/jpeg".to_string(),
+            width: None,
+            height: None,
+            file_size: 0,
+        };
+
+        let bytes = resolve_book_page_bytes(&media, &page, 1)
+            .await
+            .expect("zip page bytes should read");
+        assert_eq!(bytes, Some(b"page-1".to_vec()));
+
+        let page2 = BookPageRecord {
+            number: 2,
+            file_name: String::new(),
+            media_type: "image/jpeg".to_string(),
+            width: None,
+            height: None,
+            file_size: 0,
+        };
+        let bytes2 = resolve_book_page_bytes(&media, &page2, 2)
+            .await
+            .expect("zip page bytes should read");
+        assert_eq!(bytes2, Some(b"page-2".to_vec()));
 
         let _ = fs::remove_file(file_path);
     }

--- a/komga-rust/crates/infrastructure/media-library/src/library_scan/scan_persist.rs
+++ b/komga-rust/crates/infrastructure/media-library/src/library_scan/scan_persist.rs
@@ -1,5 +1,6 @@
 use anyhow::Context;
 use std::collections::HashSet;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use komga_application::runtime_sse::RuntimeSseEventSink;
 use komga_domain::discovery::compare_book_names;
@@ -274,6 +275,10 @@ VALUES (?, datetime(?, 'unixepoch'), ?, ?, ?, ?)"#,
                 || scanned
                     .series_ids_requiring_book_sync
                     .contains(&series.series_id);
+            let created_date_unix_seconds = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .context("system clock is before UNIX_EPOCH")?
+                .as_secs() as i64;
             for book in &series.books {
                 if sync_books || !active_book_ids.contains(&book.book_id) {
                     let book_updated = sqlx::query(
@@ -310,8 +315,8 @@ WHERE ID = ?
                     if book_updated == 0 {
                         let inserted = sqlx::query(
                                 r#"INSERT OR IGNORE INTO BOOK (ID, FILE_LAST_MODIFIED, NAME, URL, SERIES_ID, FILE_SIZE,
-                             LIBRARY_ID, oneshot)
-VALUES (?, datetime(?, 'unixepoch'), ?, ?, ?, ?, ?, ?)"#,
+                             LIBRARY_ID, oneshot, CREATED_DATE)
+VALUES (?, datetime(?, 'unixepoch'), ?, ?, ?, ?, ?, ?, datetime(?, 'unixepoch'))"#,
                             )
                             .bind(&book.book_id)
                             .bind(book.file_last_modified_unix_seconds)
@@ -321,6 +326,7 @@ VALUES (?, datetime(?, 'unixepoch'), ?, ?, ?, ?, ?, ?)"#,
                             .bind(book.file_size)
                             .bind(&library_id)
                             .bind(book.oneshot)
+                            .bind(created_date_unix_seconds)
                             .execute(pool)
                             .await
                             .context("failed to insert BOOK rows")?

--- a/komga-rust/crates/infrastructure/media-metadata/src/book_metadata.rs
+++ b/komga-rust/crates/infrastructure/media-metadata/src/book_metadata.rs
@@ -66,7 +66,7 @@ async fn load_book_metadata(
     };
 
     let author_rows = sqlx::query(
-        "SELECT NAME, ROLE FROM BOOK_METADATA_AUTHOR WHERE BOOK_ID = ? ORDER BY ROLE ASC, NAME ASC",
+        "SELECT NAME, ROLE FROM BOOK_METADATA_AUTHOR WHERE BOOK_ID = ? ORDER BY rowid ASC",
     )
     .bind(book_id)
     .fetch_all(pool)
@@ -74,7 +74,7 @@ async fn load_book_metadata(
     .context("query existing book metadata authors")?;
 
     let tag_rows = sqlx::query(
-        "SELECT TAG FROM BOOK_METADATA_TAG WHERE BOOK_ID = ? ORDER BY TAG COLLATE NOCASE ASC",
+        "SELECT DISTINCT TAG FROM BOOK_METADATA_TAG WHERE BOOK_ID = ? ORDER BY rowid ASC",
     )
     .bind(book_id)
     .fetch_all(pool)
@@ -82,7 +82,7 @@ async fn load_book_metadata(
     .context("query existing book metadata tags")?;
 
     let link_rows = sqlx::query(
-        "SELECT LABEL, URL FROM BOOK_METADATA_LINK WHERE BOOK_ID = ? ORDER BY LABEL COLLATE NOCASE ASC, URL ASC",
+        "SELECT LABEL, URL FROM BOOK_METADATA_LINK WHERE BOOK_ID = ? ORDER BY rowid ASC",
     )
     .bind(book_id)
     .fetch_all(pool)
@@ -247,4 +247,83 @@ async fn persist_book_metadata(
         .await
         .context("commit book metadata update tx")?;
     Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use komga_infrastructure_test_support::BootstrappedBookFixture;
+
+    #[tokio::test]
+    async fn load_book_metadata_preserves_author_tag_link_insertion_order() {
+        let fixture = BootstrappedBookFixture::open("book-metadata-order").await;
+        fixture.insert_library_series().await;
+        fixture.insert_book("book-1").await;
+        fixture.insert_book_metadata("book-1").await;
+
+        for (name, role) in [("Zed", "artist"), ("Alpha", "writer"), ("Zed", "artist")] {
+            sqlx::query("INSERT INTO BOOK_METADATA_AUTHOR (BOOK_ID, NAME, ROLE) VALUES (?, ?, ?)")
+                .bind("book-1")
+                .bind(name)
+                .bind(role)
+                .execute(&fixture.pool)
+                .await
+                .expect("book author should be inserted");
+        }
+        for tag in ["Omega", "Beta", "Omega"] {
+            sqlx::query("INSERT INTO BOOK_METADATA_TAG (BOOK_ID, TAG) VALUES (?, ?)")
+                .bind("book-1")
+                .bind(tag)
+                .execute(&fixture.pool)
+                .await
+                .expect("book metadata tag should be inserted");
+        }
+        for (label, url) in [("Zed", "https://z.example"), ("Alpha", "https://a.example")] {
+            sqlx::query("INSERT INTO BOOK_METADATA_LINK (BOOK_ID, LABEL, URL) VALUES (?, ?, ?)")
+                .bind("book-1")
+                .bind(label)
+                .bind(url)
+                .execute(&fixture.pool)
+                .await
+                .expect("book metadata link should be inserted");
+        }
+
+        let metadata = load_book_metadata(&fixture.pool, "book-1")
+            .await
+            .expect("book metadata should load")
+            .expect("book metadata should exist");
+
+        assert_eq!(
+            metadata.authors,
+            vec![
+                BookMetadataAuthor {
+                    name: "Zed".to_string(),
+                    role: "artist".to_string(),
+                },
+                BookMetadataAuthor {
+                    name: "Alpha".to_string(),
+                    role: "writer".to_string(),
+                },
+                BookMetadataAuthor {
+                    name: "Zed".to_string(),
+                    role: "artist".to_string(),
+                },
+            ]
+        );
+        assert_eq!(metadata.tags, vec!["Omega", "Beta"]);
+        assert_eq!(
+            metadata.links,
+            vec![
+                BookMetadataLink {
+                    label: "Zed".to_string(),
+                    url: "https://z.example".to_string(),
+                },
+                BookMetadataLink {
+                    label: "Alpha".to_string(),
+                    url: "https://a.example".to_string(),
+                },
+            ]
+        );
+        fixture.close().await;
+    }
 }

--- a/komga-rust/crates/infrastructure/media-metadata/src/refresh/queries.rs
+++ b/komga-rust/crates/infrastructure/media-metadata/src/refresh/queries.rs
@@ -102,7 +102,7 @@ pub(super) async fn load_book_metadata_for_refresh(
     };
 
     let author_rows = sqlx::query(
-        "SELECT NAME, ROLE FROM BOOK_METADATA_AUTHOR WHERE BOOK_ID = ? ORDER BY ROLE ASC, NAME ASC",
+        "SELECT NAME, ROLE FROM BOOK_METADATA_AUTHOR WHERE BOOK_ID = ? ORDER BY rowid ASC",
     )
     .bind(book_id)
     .fetch_all(pool)
@@ -110,7 +110,7 @@ pub(super) async fn load_book_metadata_for_refresh(
     .context("query existing book metadata authors for refresh: ")?;
 
     let tag_rows = sqlx::query(
-        "SELECT TAG FROM BOOK_METADATA_TAG WHERE BOOK_ID = ? ORDER BY TAG COLLATE NOCASE ASC",
+        "SELECT DISTINCT TAG FROM BOOK_METADATA_TAG WHERE BOOK_ID = ? ORDER BY rowid ASC",
     )
     .bind(book_id)
     .fetch_all(pool)
@@ -118,7 +118,7 @@ pub(super) async fn load_book_metadata_for_refresh(
     .context("query existing book metadata tags for refresh")?;
 
     let link_rows = sqlx::query(
-        "SELECT LABEL, URL FROM BOOK_METADATA_LINK WHERE BOOK_ID = ? ORDER BY LABEL COLLATE NOCASE ASC, URL ASC",
+        "SELECT LABEL, URL FROM BOOK_METADATA_LINK WHERE BOOK_ID = ? ORDER BY rowid ASC",
     )
     .bind(book_id)
     .fetch_all(pool)

--- a/komga-rust/crates/infrastructure/media-metadata/src/refresh/series_metadata.rs
+++ b/komga-rust/crates/infrastructure/media-metadata/src/refresh/series_metadata.rs
@@ -199,7 +199,7 @@ async fn load_series_metadata_refresh_state(
     };
 
     let genres = sqlx::query(
-        "SELECT GENRE FROM SERIES_METADATA_GENRE WHERE SERIES_ID = ? ORDER BY GENRE COLLATE NOCASE ASC",
+        "SELECT DISTINCT GENRE FROM SERIES_METADATA_GENRE WHERE SERIES_ID = ? ORDER BY rowid ASC",
     )
     .bind(series_id)
     .fetch_all(pool)

--- a/komga-rust/crates/infrastructure/opds/src/catalog_adapter.rs
+++ b/komga-rust/crates/infrastructure/opds/src/catalog_adapter.rs
@@ -438,8 +438,7 @@ JOIN SERIES s ON s.ID = sm.SERIES_ID
 WHERE sm.PUBLISHER IS NOT NULL
     AND trim(sm.PUBLISHER) != ''
     AND s.DELETED_DATE IS NULL
-    AND (? IS NULL OR s.LIBRARY_ID = ?)
-ORDER BY lower(sm.PUBLISHER), sm.PUBLISHER"#,
+    AND (? IS NULL OR s.LIBRARY_ID = ?)"#,
     )
     .bind(library_id)
     .bind(library_id)
@@ -459,6 +458,11 @@ ORDER BY lower(sm.PUBLISHER), sm.PUBLISHER"#,
         }
         navigation.push(BrowsePublisherEntry { publisher });
     }
+
+    navigation.sort_by(|left, right| {
+        komga_domain::discovery::system_locale_collator()
+            .compare(&left.publisher, &right.publisher)
+    });
 
     Ok(navigation)
 }
@@ -1043,13 +1047,7 @@ OFFSET ?"#,
             age_rating: row
                 .get::<Option<i64>, _>("AGE_RATING")
                 .map(clamp_kotlin_int_u32),
-            sharing_labels: row
-                .get::<String, _>("SHARING_LABELS")
-                .split(',')
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-                .map(str::to_string)
-                .collect(),
+            sharing_labels: parsed_sharing_labels(&row),
             last_modified: row.get::<String, _>("LAST_MODIFIED"),
         })
         .collect())

--- a/komga-rust/crates/infrastructure/opds/src/collections.rs
+++ b/komga-rust/crates/infrastructure/opds/src/collections.rs
@@ -1,16 +1,11 @@
 use std::collections::HashSet;
 
-use icu::collator::{
-    Collator,
-    options::{CollatorOptions, Strength},
-};
-use icu::locale::locale;
 use sqlx::{Row, SqlitePool};
-use unicode_normalization::{UnicodeNormalization, char::is_combining_mark};
 
 use komga_application::opds::{
     PersistedBookFeedRecord, PersistedNamedRecord, PersistedSeriesRecord,
 };
+use komga_domain::discovery::compare_book_names;
 
 use super::records::{parsed_age_rating, parsed_sharing_labels};
 
@@ -23,8 +18,7 @@ pub(super) async fn load_publishers(
 FROM SERIES_METADATA sm
 JOIN SERIES s ON s.ID = sm.SERIES_ID
 WHERE sm.PUBLISHER IS NOT NULL
-  AND trim(sm.PUBLISHER) != ''
-ORDER BY lower(sm.PUBLISHER), sm.PUBLISHER"#,
+  AND trim(sm.PUBLISHER) != ''"#,
     )
     .fetch_all(pool)
     .await?;
@@ -46,24 +40,11 @@ ORDER BY lower(sm.PUBLISHER), sm.PUBLISHER"#,
         }
     }
 
-    values.sort_by_cached_key(|value| unicode_collation_sort_key(value));
+    values.sort_by(|left, right| {
+        komga_domain::discovery::system_locale_collator().compare(left, right)
+    });
 
     Ok(values)
-}
-
-pub(super) fn unicode_collation_sort_key(value: &str) -> String {
-    value
-        .nfd()
-        .filter(|ch| !is_combining_mark(*ch))
-        .flat_map(|ch| ch.to_lowercase())
-        .collect()
-}
-
-fn tertiary_unicode_collator() -> icu::collator::CollatorBorrowed<'static> {
-    let mut options = CollatorOptions::default();
-    options.strength = Some(Strength::Tertiary);
-    Collator::try_new(locale!("und").into(), options)
-        .expect("unicode collator for OPDS collection sorting should construct")
 }
 
 pub(super) async fn load_collections(
@@ -77,8 +58,7 @@ pub(super) async fn load_collections(
 FROM COLLECTION c
 JOIN COLLECTION_SERIES cs ON cs.COLLECTION_ID = c.ID
 JOIN SERIES s ON s.ID = cs.SERIES_ID
-WHERE s.LIBRARY_ID = ?
-ORDER BY c.NAME COLLATE NOCASE ASC, c.ID ASC"#,
+WHERE s.LIBRARY_ID = ?"#,
         )
         .bind(library_id)
         .fetch_all(pool)
@@ -86,8 +66,7 @@ ORDER BY c.NAME COLLATE NOCASE ASC, c.ID ASC"#,
     } else {
         sqlx::query(
             r#"SELECT ID, NAME, ORDERED, COALESCE(LAST_MODIFIED_DATE, CREATED_DATE, '') AS LAST_MODIFIED
-FROM COLLECTION
-ORDER BY NAME COLLATE NOCASE ASC, ID ASC"#,
+FROM COLLECTION"#,
         )
         .fetch_all(pool)
         .await?
@@ -103,9 +82,8 @@ ORDER BY NAME COLLATE NOCASE ASC, ID ASC"#,
         })
         .collect::<Vec<_>>();
 
-    let collator = tertiary_unicode_collator();
     records.sort_by(|left, right| {
-        let ordering = collator.compare(left.name.as_str(), right.name.as_str());
+        let ordering = compare_book_names(left.name.as_str(), right.name.as_str());
         if ordering.is_eq() {
             left.id.cmp(&right.id)
         } else {
@@ -193,6 +171,7 @@ pub(super) async fn load_collection_series(
 ) -> Result<Vec<PersistedSeriesRecord>, sqlx::Error> {
     let query = if ordered {
         r#"SELECT s.ID, s.LIBRARY_ID, COALESCE(sm.TITLE, s.NAME) AS TITLE,
+       COALESCE(sm.TITLE_SORT, sm.TITLE, s.NAME) AS TITLE_SORT,
        COALESCE(sm.AGE_RATING, NULL) AS AGE_RATING,
        COALESCE((SELECT GROUP_CONCAT(LABEL, char(30))
                  FROM (SELECT DISTINCT sms_inner.LABEL AS LABEL
@@ -206,12 +185,13 @@ LEFT JOIN SERIES_METADATA_SHARING sms ON sms.SERIES_ID = s.ID
 WHERE cs.COLLECTION_ID = ?
   AND s.DELETED_DATE IS NULL
 GROUP BY s.ID, s.LIBRARY_ID, COALESCE(sm.TITLE, s.NAME),
+         COALESCE(sm.TITLE_SORT, sm.TITLE, s.NAME),
          COALESCE(sm.AGE_RATING, NULL),
          COALESCE(s.LAST_MODIFIED_DATE, s.CREATED_DATE, '')
-ORDER BY cs.NUMBER ASC, COALESCE(sm.TITLE_SORT, sm.TITLE, s.NAME) COLLATE NOCASE ASC,
-         s.ID ASC"#
+ORDER BY cs.NUMBER ASC, s.ID ASC"#
     } else {
         r#"SELECT s.ID, s.LIBRARY_ID, COALESCE(sm.TITLE, s.NAME) AS TITLE,
+       COALESCE(sm.TITLE_SORT, sm.TITLE, s.NAME) AS TITLE_SORT,
        COALESCE(sm.AGE_RATING, NULL) AS AGE_RATING,
        COALESCE((SELECT GROUP_CONCAT(LABEL, char(30))
                  FROM (SELECT DISTINCT sms_inner.LABEL AS LABEL
@@ -225,25 +205,41 @@ LEFT JOIN SERIES_METADATA_SHARING sms ON sms.SERIES_ID = s.ID
 WHERE cs.COLLECTION_ID = ?
   AND s.DELETED_DATE IS NULL
 GROUP BY s.ID, s.LIBRARY_ID, COALESCE(sm.TITLE, s.NAME),
+         COALESCE(sm.TITLE_SORT, sm.TITLE, s.NAME),
          COALESCE(sm.AGE_RATING, NULL),
-         COALESCE(s.LAST_MODIFIED_DATE, s.CREATED_DATE, '')
-ORDER BY COALESCE(sm.TITLE_SORT, sm.TITLE, s.NAME) COLLATE NOCASE ASC, s.ID ASC"#
+         COALESCE(s.LAST_MODIFIED_DATE, s.CREATED_DATE, '')"#
     };
     let rows = sqlx::query(query)
         .bind(collection_id)
         .fetch_all(pool)
         .await?;
 
-    Ok(rows
+    let mut series: Vec<(String, PersistedSeriesRecord)> = rows
         .into_iter()
-        .map(|row| PersistedSeriesRecord {
-            id: row.get::<String, _>("ID"),
-            library_id: row.get::<String, _>("LIBRARY_ID"),
-            title: row.get::<String, _>("TITLE"),
-            summary: String::new(),
-            age_rating: parsed_age_rating(&row),
-            sharing_labels: parsed_sharing_labels(&row),
-            last_modified: row.get::<String, _>("LAST_MODIFIED"),
+        .map(|row| {
+            let title_sort = row.get::<String, _>("TITLE_SORT");
+            (
+                title_sort,
+                PersistedSeriesRecord {
+                    id: row.get::<String, _>("ID"),
+                    library_id: row.get::<String, _>("LIBRARY_ID"),
+                    title: row.get::<String, _>("TITLE"),
+                    summary: String::new(),
+                    age_rating: parsed_age_rating(&row),
+                    sharing_labels: parsed_sharing_labels(&row),
+                    last_modified: row.get::<String, _>("LAST_MODIFIED"),
+                },
+            )
         })
-        .collect())
+        .collect();
+    if !ordered {
+        let collator = komga_domain::discovery::system_locale_collator();
+        series.sort_by(|left, right| {
+            collator
+                .compare(&left.0, &right.0)
+                .then_with(|| left.1.id.cmp(&right.1.id))
+        });
+    }
+
+    Ok(series.into_iter().map(|(_, record)| record).collect())
 }

--- a/komga-rust/crates/infrastructure/opds/src/persisted_adapter.rs
+++ b/komga-rust/crates/infrastructure/opds/src/persisted_adapter.rs
@@ -19,7 +19,6 @@ use komga_infrastructure_base::DatabaseHandle;
 use komga_infrastructure_search::SearchEntityType;
 use komga_infrastructure_search::engine::SearchIndexEngine;
 
-use super::collections::unicode_collation_sort_key;
 use super::collections::{
     load_collection, load_collection_books, load_collection_series, load_collections,
     load_publishers,
@@ -441,14 +440,13 @@ async fn load_readlists_for_library(
 FROM READLIST rl
 JOIN READLIST_BOOK rb ON rb.READLIST_ID = rl.ID
 JOIN BOOK b ON b.ID = rb.BOOK_ID
-WHERE b.LIBRARY_ID = ?
-ORDER BY rl.NAME COLLATE NOCASE ASC, rl.ID ASC"#,
+WHERE b.LIBRARY_ID = ?"#,
     )
     .bind(library_id)
     .fetch_all(pool)
     .await?;
 
-    Ok(rows
+    let mut records: Vec<PersistedReadlistRecord> = rows
         .into_iter()
         .map(|row| PersistedReadlistRecord {
             id: row.get::<String, _>("ID"),
@@ -456,7 +454,14 @@ ORDER BY rl.NAME COLLATE NOCASE ASC, rl.ID ASC"#,
             last_modified: row.get::<String, _>("LAST_MODIFIED"),
             ordered: row.get::<bool, _>("ORDERED"),
         })
-        .collect())
+        .collect();
+    records.sort_by(|left, right| {
+        komga_domain::discovery::system_locale_collator()
+            .compare(&left.name, &right.name)
+            .then_with(|| left.id.cmp(&right.id))
+    });
+
+    Ok(records)
 }
 
 async fn load_all_readlists(
@@ -468,13 +473,12 @@ async fn load_all_readlists(
     NAME,
     ORDERED,
     COALESCE(LAST_MODIFIED_DATE, CREATED_DATE, '') AS LAST_MODIFIED
-FROM READLIST
-ORDER BY NAME COLLATE NOCASE ASC, ID ASC"#,
+FROM READLIST"#,
     )
     .fetch_all(pool)
     .await?;
 
-    Ok(rows
+    let mut records: Vec<PersistedReadlistRecord> = rows
         .into_iter()
         .map(|row| PersistedReadlistRecord {
             id: row.get::<String, _>("ID"),
@@ -482,7 +486,14 @@ ORDER BY NAME COLLATE NOCASE ASC, ID ASC"#,
             last_modified: row.get::<String, _>("LAST_MODIFIED"),
             ordered: row.get::<bool, _>("ORDERED"),
         })
-        .collect())
+        .collect();
+    records.sort_by(|left, right| {
+        komga_domain::discovery::system_locale_collator()
+            .compare(&left.name, &right.name)
+            .then_with(|| left.id.cmp(&right.id))
+    });
+
+    Ok(records)
 }
 
 async fn load_series(
@@ -626,19 +637,23 @@ async fn load_series_tags(pool: &SqlitePool, series_id: &str) -> Result<Vec<Stri
         r#"SELECT DISTINCT bt.TAG AS TAG
 FROM BOOK_METADATA_TAG bt
 LEFT JOIN BOOK b ON bt.BOOK_ID = b.ID
-WHERE b.SERIES_ID = ?
-ORDER BY bt.TAG COLLATE NOCASE ASC, bt.TAG ASC"#,
+WHERE b.SERIES_ID = ?"#,
     )
     .bind(series_id)
     .fetch_all(pool)
     .await?;
 
-    Ok(rows
+    let mut tags = rows
         .into_iter()
         .map(|row| row.get::<String, _>("TAG"))
         .map(|tag| tag.trim().to_string())
         .filter(|tag| !tag.is_empty())
-        .collect())
+        .collect::<Vec<_>>();
+    tags.sort_by(|left, right| {
+        komga_domain::discovery::system_locale_collator().compare(left, right)
+    });
+
+    Ok(tags)
 }
 
 async fn load_readlist(
@@ -979,7 +994,9 @@ WHERE ID IN ({})"#,
         })
         .collect::<Vec<_>>();
 
-    records.sort_by_cached_key(|record| unicode_collation_sort_key(record.name.as_str()));
+    records.sort_by(|left, right| {
+        komga_domain::discovery::system_locale_collator().compare(&left.name, &right.name)
+    });
 
     Ok(records)
 }
@@ -1106,11 +1123,8 @@ async fn load_collection_search_records_limited(
 ) -> Result<Vec<PersistedNamedRecord>, sqlx::Error> {
     let rows = sqlx::query(
         r#"SELECT ID, NAME, ORDERED, COALESCE(LAST_MODIFIED_DATE, CREATED_DATE, '') AS LAST_MODIFIED
-FROM COLLECTION
-ORDER BY NAME COLLATE NOCASE ASC, ID ASC
-LIMIT ?"#,
+FROM COLLECTION"#,
     )
-    .bind(limit)
     .fetch_all(pool)
     .await?;
     let mut records = rows
@@ -1123,7 +1137,12 @@ LIMIT ?"#,
         })
         .collect::<Vec<_>>();
 
-    records.sort_by_cached_key(|record| unicode_collation_sort_key(record.name.as_str()));
+    records.sort_by(|left, right| {
+        komga_domain::discovery::system_locale_collator()
+            .compare(&left.name, &right.name)
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    records.truncate(limit as usize);
 
     Ok(records)
 }
@@ -1134,14 +1153,11 @@ async fn load_readlist_search_records_limited(
 ) -> Result<Vec<PersistedNamedRecord>, sqlx::Error> {
     let rows = sqlx::query(
         r#"SELECT ID, NAME, ORDERED, COALESCE(LAST_MODIFIED_DATE, CREATED_DATE, '') AS LAST_MODIFIED
-FROM READLIST
-ORDER BY NAME COLLATE NOCASE ASC, ID ASC
-LIMIT ?"#,
+FROM READLIST"#,
     )
-    .bind(limit)
     .fetch_all(pool)
     .await?;
-    Ok(rows
+    let mut records: Vec<PersistedNamedRecord> = rows
         .into_iter()
         .map(|row| PersistedNamedRecord {
             id: row.get::<String, _>("ID"),
@@ -1149,7 +1165,15 @@ LIMIT ?"#,
             last_modified: row.get::<String, _>("LAST_MODIFIED"),
             ordered: row.get::<bool, _>("ORDERED"),
         })
-        .collect())
+        .collect();
+    records.sort_by(|left, right| {
+        komga_domain::discovery::system_locale_collator()
+            .compare(&left.name, &right.name)
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    records.truncate(limit as usize);
+
+    Ok(records)
 }
 #[cfg(test)]
 mod tests {
@@ -1218,4 +1242,65 @@ mod tests {
         assert!(readlist_rows_limited[0].ordered);
         pool.close().await;
     }
+    #[tokio::test]
+    async fn limited_named_records_sort_icu_and_keep_icu_boundary_members() {
+        let pool = open_bootstrapped_pool("opds-limited-icu-boundary").await;
+        // Names deliberately mix case so SQLite COLLATE NOCASE ties "Alpha" and
+        // "alpha" (preserving insertion order), while the ICU collator orders
+        // lowercase before uppercase. A NOCASE + LIMIT query would therefore
+        // return "Alpha" for limit=1; the ICU ordering must return "alpha".
+        let names = ["Alpha", "alpha", "Beta", "gamma", "Zulu"];
+        for (index, name) in names.iter().enumerate() {
+            sqlx::query(
+                "INSERT INTO COLLECTION (ID, NAME, ORDERED, SERIES_COUNT) VALUES (?, ?, ?, ?)",
+            )
+            .bind(format!("collection-{index}"))
+            .bind(*name)
+            .bind(false)
+            .bind(0_i64)
+            .execute(&pool)
+            .await
+            .expect("collection should be inserted");
+            sqlx::query("INSERT INTO READLIST (ID, NAME, BOOK_COUNT, ORDERED) VALUES (?, ?, ?, ?)")
+                .bind(format!("readlist-{index}"))
+                .bind(*name)
+                .bind(0_i64)
+                .bind(false)
+                .execute(&pool)
+                .await
+                .expect("readlist should be inserted");
+        }
+
+        let collator = komga_domain::discovery::system_locale_collator();
+        let mut expected = names.to_vec();
+        expected.sort_by(|left, right| collator.compare(left, right));
+
+        let collection_rows = load_collection_search_records_limited(&pool, 20)
+            .await
+            .expect("limited collection search rows should load");
+        let readlist_rows = load_readlist_search_records_limited(&pool, 20)
+            .await
+            .expect("limited readlist search rows should load");
+        let collection_names: Vec<&str> = collection_rows
+            .iter()
+            .map(|record| record.name.as_str())
+            .collect();
+        let readlist_names: Vec<&str> = readlist_rows
+            .iter()
+            .map(|record| record.name.as_str())
+            .collect();
+        assert_eq!(collection_names, expected, "collections should follow ICU order");
+        assert_eq!(readlist_names, expected, "readlists should follow ICU order");
+
+        let collection_one = load_collection_search_records_limited(&pool, 1)
+            .await
+            .expect("limited collection search rows should load");
+        let readlist_one = load_readlist_search_records_limited(&pool, 1)
+            .await
+            .expect("limited readlist search rows should load");
+        assert_eq!(collection_one[0].name, "alpha", "limit boundary must use the ICU-first member");
+        assert_eq!(readlist_one[0].name, "alpha", "limit boundary must use the ICU-first member");
+        pool.close().await;
+    }
+
 }

--- a/komga-rust/crates/interfaces/src/discovery/books/duplicates.rs
+++ b/komga-rust/crates/interfaces/src/discovery/books/duplicates.rs
@@ -2,11 +2,6 @@ use axum::Json;
 use axum::extract::State;
 use axum::http::Uri;
 use axum::response::{IntoResponse, Response};
-use icu::collator::{
-    Collator,
-    options::{CollatorOptions, Strength},
-};
-use icu::locale::locale;
 
 use crate::contracts::common::PageDto;
 use crate::contracts::discovery::BookDto;
@@ -14,6 +9,7 @@ use crate::helpers::{query_bool, query_value, query_values};
 use crate::identity_access::auth::Admin;
 use crate::state::DiscoveryState;
 use komga_application::identity_access::user_id;
+use komga_domain::discovery::compare_book_names;
 
 use super::super::persisted::common_helpers::{decode_query_component, internal_error_response};
 
@@ -75,21 +71,13 @@ struct DuplicateBooksPageSlice {
     total_elements: usize,
 }
 
-fn duplicate_books_unicode_collator() -> icu::collator::CollatorBorrowed<'static> {
-    let mut options = CollatorOptions::default();
-    options.strength = Some(Strength::Tertiary);
-    Collator::try_new(locale!("und").into(), options)
-        .expect("unicode collator for duplicate books sorting should construct")
-}
-
-fn compare_duplicate_book_unicode_strings(
-    collator: &icu::collator::CollatorBorrowed<'_>,
+fn compare_duplicate_book_names(
     left: Option<&str>,
     right: Option<&str>,
     descending: bool,
 ) -> std::cmp::Ordering {
     let ordering = match (left, right) {
-        (Some(left), Some(right)) => collator.compare(left, right),
+        (Some(left), Some(right)) => compare_book_names(left, right),
         (None, Some(_)) => std::cmp::Ordering::Less,
         (Some(_), None) => std::cmp::Ordering::Greater,
         (None, None) => std::cmp::Ordering::Equal,
@@ -193,18 +181,15 @@ fn sort_duplicate_book_payloads(
     books: &mut [DuplicateBookPayload],
     sort_modes: &[DuplicateBooksSortMode],
 ) {
-    let unicode_collator = duplicate_books_unicode_collator();
     books.sort_by(|left, right| {
         for sort_mode in sort_modes {
             let ordering = match sort_mode.field {
-                DuplicateBooksSortField::Name => compare_duplicate_book_unicode_strings(
-                    &unicode_collator,
+                DuplicateBooksSortField::Name => compare_duplicate_book_names(
                     Some(left.payload.name.as_str()),
                     Some(right.payload.name.as_str()),
                     sort_mode.descending,
                 ),
-                DuplicateBooksSortField::Series => compare_duplicate_book_unicode_strings(
-                    &unicode_collator,
+                DuplicateBooksSortField::Series => compare_duplicate_book_names(
                     Some(left.series_title_sort.as_str()),
                     Some(right.series_title_sort.as_str()),
                     sort_mode.descending,
@@ -254,8 +239,7 @@ fn sort_duplicate_book_payloads(
                     right.payload.media.pages_count,
                     sort_mode.descending,
                 ),
-                DuplicateBooksSortField::MetadataTitle => compare_duplicate_book_unicode_strings(
-                    &unicode_collator,
+                DuplicateBooksSortField::MetadataTitle => compare_duplicate_book_names(
                     Some(left.payload.metadata.title.as_str()),
                     Some(right.payload.metadata.title.as_str()),
                     sort_mode.descending,

--- a/komga-rust/crates/interfaces/src/discovery/detail/collections.rs
+++ b/komga-rust/crates/interfaces/src/discovery/detail/collections.rs
@@ -18,7 +18,7 @@ use komga_application::discovery::{
     CollectionMutationError, CollectionMutationInput, CollectionReadModel, PageRequest,
     SeriesBrowseRequest, SeriesReadModel,
 };
-use komga_domain::discovery::PageEnvelope;
+use komga_domain::discovery::{PageEnvelope, SeriesSort};
 use serde_json::{Value, json};
 use std::collections::{BTreeSet, HashMap};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -178,7 +178,11 @@ pub(crate) async fn collection_series(
             &domain_context,
             SeriesBrowseRequest {
                 filter,
-                sort: vec![],
+                sort: if collection.ordered {
+                    vec![]
+                } else {
+                    vec![SeriesSort::MetadataTitleSortAsc]
+                },
                 search: None,
                 page: PageRequest {
                     page,

--- a/komga-rust/crates/interfaces/src/discovery/facets.rs
+++ b/komga-rust/crates/interfaces/src/discovery/facets.rs
@@ -304,8 +304,15 @@ async fn author_values_v2_handler(
         .into_iter()
         .map(|author| if names { author.name } else { author.role })
         .collect::<Vec<_>>();
+    // Deduplicate on exact string equality first: canonically equivalent
+    // Unicode strings (e.g. "é" and "e\u{301}") compare equal under ICU but
+    // are distinct strings, so a collation-only dedup can keep repeated exact
+    // values. Byte-order sort, dedup, then sort by the active collation.
     values.sort();
     values.dedup();
+    values.sort_by(|left, right| {
+        komga_domain::discovery::system_locale_collator().compare(left, right)
+    });
 
     Json(paged_values_payload(
         values.into_iter().map(FacetValueDto::String).collect(),

--- a/komga-rust/crates/interfaces/src/discovery/request_resolution/books.rs
+++ b/komga-rust/crates/interfaces/src/discovery/request_resolution/books.rs
@@ -865,11 +865,33 @@ pub(super) fn parse_book_sorts_from_json(sorts: Option<&Value>, has_search: bool
     parse_book_sorts_from_json_values(&strs, has_search)
 }
 
+fn expand_book_sort_string(s: &str) -> Vec<String> {
+    let parts: Vec<&str> = s.split(',').collect();
+    if parts.len() <= 2 {
+        return vec![s.to_string()];
+    }
+
+    let direction = parts.last().map(|p| p.trim()).unwrap_or_default();
+    if !direction.eq_ignore_ascii_case("asc") && !direction.eq_ignore_ascii_case("desc") {
+        return vec![s.to_string()];
+    }
+
+    parts[..parts.len() - 1]
+        .iter()
+        .map(|field| format!("{},{}", field.trim(), direction))
+        .collect()
+}
+
 pub(super) fn parse_book_sorts_from_json_values(
     sorts: &[String],
     has_search: bool,
 ) -> Vec<BookSort> {
-    let mut result = sorts
+    let expanded: Vec<String> = sorts
+        .iter()
+        .flat_map(|s| expand_book_sort_string(s.trim()))
+        .collect();
+
+    let mut result = expanded
         .iter()
         .filter_map(|s| {
             let trimmed = s.trim();
@@ -910,9 +932,7 @@ pub(super) fn parse_book_sorts_from_json_values(
                 }
                 "metadata.releaseDate,asc" => Some(BookSort::ReleaseDateAsc),
                 "metadata.releaseDate,desc" => Some(BookSort::ReleaseDateDesc),
-                "metadata.numberSort,asc" | "number,asc" | "series,metadata.numberSort,asc" => {
-                    Some(BookSort::NumberSortAsc)
-                }
+                "metadata.numberSort,asc" | "number,asc" => Some(BookSort::NumberSortAsc),
                 "metadata.numberSort,desc" | "number,desc" => Some(BookSort::NumberSortDesc),
                 "seriesId,asc" => Some(BookSort::SeriesIdAsc),
                 "readList.number,asc" | "readList.number" => Some(BookSort::ReadListNumberAsc),
@@ -924,7 +944,7 @@ pub(super) fn parse_book_sorts_from_json_values(
         })
         .collect::<Vec<_>>();
     result.dedup();
-    if result.is_empty() && sorts.is_empty() && has_search {
+    if result.is_empty() && expanded.is_empty() && has_search {
         result.push(BookSort::RelevanceAsc);
     }
     result

--- a/komga-rust/crates/interfaces/src/discovery/request_resolution/collections.rs
+++ b/komga-rust/crates/interfaces/src/discovery/request_resolution/collections.rs
@@ -1,6 +1,6 @@
-use komga_application::discovery::CollectionListQuery;
+use komga_application::discovery::{CollectionListQuery, CollectionsSort};
 
-use super::{query_bool, query_value, query_values};
+use super::{decode_query_component, query_bool, query_value, query_values};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ResolvedCollectionListRequest {
@@ -25,6 +25,13 @@ pub fn resolve_collection_list_request(query: &str) -> ResolvedCollectionListReq
         .map(str::to_string)
         .collect::<Vec<_>>();
     let unpaged = query_bool(query, "unpaged");
+    let sort = query_values(query, "sort")
+        .into_iter()
+        .map(|value| decode_query_component(value.trim()))
+        .find(|value| !value.is_empty())
+        .as_deref()
+        .map(parse_collections_sort)
+        .unwrap_or(CollectionsSort::SearchOrName);
 
     ResolvedCollectionListRequest {
         query: CollectionListQuery {
@@ -32,7 +39,36 @@ pub fn resolve_collection_list_request(query: &str) -> ResolvedCollectionListReq
             size,
             unpaged,
             search,
+            sort,
         },
         requested_library_ids,
+    }
+}
+
+pub fn parse_collections_sort(value: &str) -> CollectionsSort {
+    let mut parts = value.splitn(2, ',');
+    let field = parts.next().unwrap_or_default().trim();
+    let direction = parts.next().unwrap_or("asc").trim();
+
+    if field.eq_ignore_ascii_case("name") {
+        if direction.eq_ignore_ascii_case("desc") {
+            CollectionsSort::NameDesc
+        } else {
+            CollectionsSort::NameAsc
+        }
+    } else if field.eq_ignore_ascii_case("createdDate") {
+        if direction.eq_ignore_ascii_case("desc") {
+            CollectionsSort::CreatedDateDesc
+        } else {
+            CollectionsSort::CreatedDateAsc
+        }
+    } else if field.eq_ignore_ascii_case("lastModifiedDate") {
+        if direction.eq_ignore_ascii_case("desc") {
+            CollectionsSort::LastModifiedDateDesc
+        } else {
+            CollectionsSort::LastModifiedDateAsc
+        }
+    } else {
+        CollectionsSort::SearchOrName
     }
 }

--- a/komga-rust/crates/interfaces/src/discovery/request_resolution/mod.rs
+++ b/komga-rust/crates/interfaces/src/discovery/request_resolution/mod.rs
@@ -16,9 +16,9 @@ use komga_application::discovery::{
 };
 use komga_domain::common_ids::{CollectionId, LibraryId};
 use komga_domain::discovery::{
-    AgeRatingCondition, CompositeSeriesCondition, DateCondition, DiscoveryError, FilterOperator,
-    InclusionCondition, ReadStatusCondition, SeriesCondition, SeriesFilter, SeriesSort,
-    SeriesStatus, SeriesStatusCondition, SeriesValueCondition, StringCondition,
+    AgeRatingCondition, BookSort, CompositeSeriesCondition, DateCondition, DiscoveryError,
+    FilterOperator, InclusionCondition, ReadStatusCondition, SeriesCondition, SeriesFilter,
+    SeriesSort, SeriesStatus, SeriesStatusCondition, SeriesValueCondition, StringCondition,
 };
 pub use readlists::{resolve_readlist_books_query, resolve_readlists_query};
 use serde_json::Value;
@@ -165,7 +165,12 @@ pub fn resolve_deprecated_books_request(
     let search = requested_query_values(query, "search")
         .and_then(|values| values.into_iter().next())
         .filter(|value| !value.trim().is_empty());
-    let sorted = !query_values(query, "sort").is_empty() || search.is_some();
+    let query_sort_values = decoded_query_values(query, "sort");
+    let mut sort = parse_book_sorts_from_json_values(&query_sort_values, search.is_some());
+    if sort.is_empty() && search.is_some() {
+        sort.push(BookSort::RelevanceAsc);
+    }
+    let sorted = !sort.is_empty();
 
     Ok(ResolvedBooksBrowseRequest {
         request: BooksBrowseRequest {
@@ -176,7 +181,7 @@ pub fn resolve_deprecated_books_request(
                 media_statuses,
                 released_after,
             )?,
-            sort: vec![],
+            sort,
             search,
             page: PageRequest {
                 page,
@@ -194,11 +199,14 @@ pub fn resolve_series_books_request(
     query: &str,
 ) -> Result<ResolvedBooksBrowseRequest, DiscoveryRequestError> {
     let filter = legacy_series_books_book_filter(series_id, query)?;
-    let sort = legacy_series_books_sort_from_query(query);
+    let mut sort = legacy_series_books_sort_from_query(query);
+    if sort.is_empty() {
+        sort.push(BookSort::NumberSortAsc);
+    }
+    let sorted = !sort.is_empty();
     let page = query_usize(query, "page", 0);
     let size = query_usize(query, "size", 20).max(1);
     let unpaged = query_bool(query, "unpaged");
-    let sorted = !query_values(query, "sort").is_empty();
 
     Ok(ResolvedBooksBrowseRequest {
         request: BooksBrowseRequest {

--- a/komga-rust/crates/server/src/bootstrap/mod.rs
+++ b/komga-rust/crates/server/src/bootstrap/mod.rs
@@ -9,6 +9,7 @@ use komga_config::cli_args::RuntimeCli;
 use komga_config::env_config::{RuntimeConfig, RuntimeDatabaseSettings};
 use komga_config::profile::{RuntimeMode, RuntimeProfile};
 use komga_config::writer_ownership::{WriterDecision, WriterKind};
+use komga_domain::discovery::set_sort_locale;
 use komga_infrastructure_base::{bootstrap_pool, bootstrap_tasks_pool};
 use komga_infrastructure_operational::ServerSettingsStore;
 use std::sync::Arc;
@@ -159,6 +160,7 @@ async fn run_server(startup_started_at: Instant) {
     let config = resolve_runtime_config_with_database(base_config)
         .await
         .expect("failed to merge persisted runtime settings");
+    set_sort_locale(config.sort_locale.clone());
     noclaim_bootstrap::ensure_noclaim_initial_users(&config).await;
 
     let listener = TcpListener::bind(config.bind_address)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Added collection sorting by name, creation date, and last-modified date, with ascending and descending options.
- Added configurable sorting locale support through application settings or the `KOMGA_SORT_LOCALE` environment variable.
- EPUB contents now preserve manifest order.
- Archive page listings are sorted by filename with sequential numbering.

## Bug Fixes

- Improved locale-aware natural sorting across books, series, collections, read lists, duplicates, facets, OPDS catalogs, and archive contents.
- Improved sort tie-breaking, multi-field sort handling, and collection search sorting.
- Metadata lists now preserve insertion order where applicable.
- Library scans now record book creation dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->