### PR TITLE
fix(rust): parsing a numeric field from a string

### DIFF
--- a/komga-rust/crates/interfaces/src/discovery/detail/series_detail.rs
+++ b/komga-rust/crates/interfaces/src/discovery/detail/series_detail.rs
@@ -312,9 +312,13 @@ fn optional_nullable_u32_field(
         return Ok(Some(None));
     }
 
-    let Some(value) = value.as_i64() else {
-        return Err(format!("{key} must be an integer or null"));
-    };
+    let value = match value {
+        Value::Number(number) => number.as_i64(),
+        Value::String(string) => string.trim().parse::<i64>().ok(),
+        _ => None,
+    }
+    .ok_or_else(|| format!("{key} must be an integer or null"))?;
+
     if !(0..=i64::from(u32::MAX)).contains(&value) {
         return Err(format!("{key} must be between 0 and {}", u32::MAX));
     }

--- a/komga-rust/crates/interfaces/src/media_assets/operations.rs
+++ b/komga-rust/crates/interfaces/src/media_assets/operations.rs
@@ -201,10 +201,17 @@ fn optional_bool(
 fn optional_f64(patch: &serde_json::Map<String, Value>, key: &str) -> anyhow::Result<Option<f64>> {
     match patch.get(key) {
         Some(value) if value.is_null() => Ok(None),
-        Some(value) => value
-            .as_f64()
-            .map(Some)
-            .ok_or_else(|| anyhow::anyhow!(format!("{key} must be a number or null"))),
+        Some(value) => {
+            let parsed = match value {
+                Value::Number(number) => number.as_f64(),
+                Value::String(string) => string.trim().parse::<f64>().ok(),
+                _ => None,
+            };
+            parsed
+                .filter(|value| value.is_finite())
+                .map(Some)
+                .ok_or_else(|| anyhow::anyhow!(format!("{key} must be a number or null")))
+        }
         None => Ok(None),
     }
 }


### PR DESCRIPTION
fix WebUI-related updates failed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metadata compatibility by accepting numeric values provided as strings for age ratings, total book counts, and number sorting.
  * Numeric strings may include surrounding whitespace and are validated for valid, finite values before being applied.
  * Invalid, unsupported, or non-finite values continue to produce validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->